### PR TITLE
Document Status Workflow — Server-side Transition Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/domain/translation/translation.service.test.ts src/lib/authorize.test.ts",
+    "test": "tsx --test src/domain/translation/translation.service.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts",
     "db:seed": "tsx prisma/seed.ts",
     "format": "prettier --write ."
   },

--- a/src/components/status-dropdown.tsx
+++ b/src/components/status-dropdown.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DOCUMENT_STATUS_SEQUENCE, getDocumentStatusConfig } from '@/constants/document-status';
 import { updateDocumentVersionStatusAction } from '@/domain/document-version/document-version.actions';
+import { VALID_TRANSITIONS } from '@/domain/document-version/document-version.transitions';
 import { canDeployClient } from '@/lib/permissions-client';
 import { SessionUser } from '@/lib/session';
 import { cn } from '@/lib/utils';
@@ -72,16 +73,10 @@ export function StatusDropdown({
       statuses = statuses.filter((status) => status !== DocumentStatus.DEPLOYED);
     }
 
-    // Restrict to adjacent statuses only (previous and next in sequence)
+    // Restrict to valid transitions from the current status
     if (currentStatus) {
-      const currentIndex = DOCUMENT_STATUS_SEQUENCE.indexOf(currentStatus);
-      if (currentIndex !== -1) {
-        const adjacentStatuses = new Set<DocumentStatus>();
-        if (currentIndex > 0) adjacentStatuses.add(DOCUMENT_STATUS_SEQUENCE[currentIndex - 1]);
-        if (currentIndex < DOCUMENT_STATUS_SEQUENCE.length - 1)
-          adjacentStatuses.add(DOCUMENT_STATUS_SEQUENCE[currentIndex + 1]);
-        statuses = statuses.filter((s) => adjacentStatuses.has(s));
-      }
+      const validTargets = VALID_TRANSITIONS[currentStatus] || [];
+      statuses = statuses.filter((s) => validTargets.includes(s));
     }
 
     return statuses;

--- a/src/domain/document-version/document-version.actions.ts
+++ b/src/domain/document-version/document-version.actions.ts
@@ -6,6 +6,8 @@ import { DocumentStatus, ProjectRole, Role } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 import { coalesceEditLog, createActivityLog } from '../activity-log/activity-log.repository';
 import { createComment } from '../comment/comment.repository';
+import { countOpenSuggestions } from '../suggestion/suggestion.repository';
+import { validateTransition } from './document-version.transitions';
 import { getDocumentAssignmentByDocumentAndProject } from '../document-assignment/document-assignment.repository';
 import { getDocumentById } from '../document/document.repository';
 import { getLanguageById } from '../language/language.repository';
@@ -172,6 +174,8 @@ export async function submitForReviewAction(input: unknown) {
     await authorize('admin');
   }
 
+  validateTransition(existingVersion.status, DocumentStatus.PENDING_REVIEW);
+
   const version = await updateDocumentVersionStatus(
     validated.versionId,
     DocumentStatus.PENDING_REVIEW,
@@ -222,8 +226,10 @@ export async function reviewVersionAction(input: unknown) {
   // Determine new status based on approval decision
   const newStatus = validated.approved
     ? DocumentStatus.APPROVED
-    : // If changes are requested, always go back to IN_PROGRESS (since it was being reviewed, it must have content)
-      DocumentStatus.IN_PROGRESS;
+    : DocumentStatus.IN_PROGRESS;
+
+  const openCount = await countOpenSuggestions(validated.versionId);
+  validateTransition(currentVersion.status, newStatus, { openSuggestionsCount: openCount });
 
   const version = await updateDocumentVersionStatus(validated.versionId, newStatus);
 
@@ -248,12 +254,17 @@ export async function reviewVersionAction(input: unknown) {
 }
 
 export async function deployVersionAction(versionId: string) {
-  console.log('[Deploy] deployVersionAction called with versionId:', versionId);
   const { user } = await authorize('can:deploy');
-  console.log('[Deploy] User:', user.id, user.name);
+
+  const currentVersion = await getDocumentVersionById(versionId);
+  if (!currentVersion) {
+    throw new Error('Document version not found');
+  }
+
+  const openCount = await countOpenSuggestions(versionId);
+  validateTransition(currentVersion.status, DocumentStatus.DEPLOYED, { openSuggestionsCount: openCount });
 
   const version = await updateDocumentVersionStatus(versionId, DocumentStatus.DEPLOYED);
-  console.log('[Deploy] Version status updated to DEPLOYED');
 
   // Log the activity
   await createActivityLog({
@@ -332,18 +343,20 @@ export async function updateDocumentVersionStatusAction(
   github?: { status: 'success' | 'failed' | 'skipped'; error?: string; prUrl?: string };
 }> {
   const { user } = await authorize('authenticated');
-  console.log('[StatusUpdate] updateDocumentVersionStatusAction called:', versionId, '→', status);
 
   // Check permission for DEPLOYED status
   if (status === DocumentStatus.DEPLOYED && user.role !== Role.ADMIN) {
     throw new Error('Forbidden: Only deployers can deploy documents');
   }
 
-  // Get existing version to check permissions
+  // Get existing version to validate transition
   const existingVersion = await getDocumentVersionById(versionId);
   if (!existingVersion) {
     throw new Error('Document version not found');
   }
+
+  const openCount = await countOpenSuggestions(versionId);
+  validateTransition(existingVersion.status, status, { openSuggestionsCount: openCount });
 
   const version = await updateDocumentVersionStatus(versionId, status);
 

--- a/src/domain/document-version/document-version.actions.ts
+++ b/src/domain/document-version/document-version.actions.ts
@@ -228,8 +228,12 @@ export async function reviewVersionAction(input: unknown) {
     ? DocumentStatus.APPROVED
     : DocumentStatus.IN_PROGRESS;
 
-  const openCount = await countOpenSuggestions(validated.versionId);
-  validateTransition(currentVersion.status, newStatus, { openSuggestionsCount: openCount });
+  if (validated.approved) {
+    const openCount = await countOpenSuggestions(validated.versionId);
+    validateTransition(currentVersion.status, newStatus, { openSuggestionsCount: openCount });
+  } else {
+    validateTransition(currentVersion.status, newStatus);
+  }
 
   const version = await updateDocumentVersionStatus(validated.versionId, newStatus);
 
@@ -355,8 +359,12 @@ export async function updateDocumentVersionStatusAction(
     throw new Error('Document version not found');
   }
 
-  const openCount = await countOpenSuggestions(versionId);
-  validateTransition(existingVersion.status, status, { openSuggestionsCount: openCount });
+  if (status === DocumentStatus.APPROVED || status === DocumentStatus.DEPLOYED) {
+    const openCount = await countOpenSuggestions(versionId);
+    validateTransition(existingVersion.status, status, { openSuggestionsCount: openCount });
+  } else {
+    validateTransition(existingVersion.status, status);
+  }
 
   const version = await updateDocumentVersionStatus(versionId, status);
 
@@ -505,9 +513,9 @@ export async function assignDocumentVersionAction(input: unknown) {
       throw new Error('This translation is already assigned to another user');
     }
 
-    // For any other status (PENDING_TRANSLATION, PENDING_REVIEW, etc.), assign to current user and set to IN_PROGRESS
-    // This handles the "Start Translation" action
-    // Update the version to assign it to current user and set status to IN_PROGRESS
+    // Assign to current user and set to IN_PROGRESS (bypasses validateTransition
+    // intentionally — this is the "Start Translation" flow which can re-claim
+    // a version from PENDING_TRANSLATION or reassign from other statuses)
     const version = await prisma.documentVersion.update({
       where: { id: existingVersion.id },
       data: {

--- a/src/domain/document-version/document-version.repository.ts
+++ b/src/domain/document-version/document-version.repository.ts
@@ -125,14 +125,7 @@ export async function createDocumentVersion(data: {
   status?: DocumentStatus;
   userId: string;
 }) {
-  // If status is explicitly provided, use it. Otherwise, determine it based on content
-  // If content is provided and not empty, set to IN_PROGRESS, otherwise PENDING_TRANSLATION
-  const finalStatus =
-    data.status !== undefined
-      ? data.status
-      : data.content.trim()
-        ? DocumentStatus.IN_PROGRESS
-        : DocumentStatus.PENDING_TRANSLATION;
+  const finalStatus = data.status ?? DocumentStatus.PENDING_TRANSLATION;
 
   return prisma.documentVersion.create({
     data: {
@@ -174,19 +167,12 @@ export async function updateDocumentVersion(id: string, content: string, userId:
     throw new Error('Document version not found');
   }
 
-  // If status is PENDING_TRANSLATION and content is provided, change to IN_PROGRESS
-  const newStatus =
-    current.status === DocumentStatus.PENDING_TRANSLATION && content.trim()
-      ? DocumentStatus.IN_PROGRESS
-      : current.status;
-
-  // Update with incremented version
+  // Update with incremented version (status unchanged — transitions are explicit)
   return prisma.documentVersion.update({
     where: { id },
     data: {
       content,
       userId,
-      status: newStatus,
       version: current.version + 1,
       updatedAt: new Date(),
     },

--- a/src/domain/document-version/document-version.transitions.test.ts
+++ b/src/domain/document-version/document-version.transitions.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DocumentStatus } from '@prisma/client';
+import { validateTransition } from './document-version.transitions';
+
+describe('validateTransition', () => {
+  describe('valid forward transitions', () => {
+    it('PENDING_TRANSLATION → IN_PROGRESS', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.PENDING_TRANSLATION, DocumentStatus.IN_PROGRESS),
+      );
+    });
+
+    it('IN_PROGRESS → PENDING_REVIEW', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.IN_PROGRESS, DocumentStatus.PENDING_REVIEW),
+      );
+    });
+
+    it('PENDING_REVIEW → APPROVED', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.APPROVED, { openSuggestionsCount: 0 }),
+      );
+    });
+
+    it('APPROVED → DEPLOYED', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.APPROVED, DocumentStatus.DEPLOYED, { openSuggestionsCount: 0 }),
+      );
+    });
+  });
+
+  describe('valid backward transitions', () => {
+    it('IN_PROGRESS → PENDING_TRANSLATION', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.IN_PROGRESS, DocumentStatus.PENDING_TRANSLATION),
+      );
+    });
+
+    it('PENDING_REVIEW → IN_PROGRESS', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.IN_PROGRESS),
+      );
+    });
+
+    it('APPROVED → PENDING_REVIEW', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.APPROVED, DocumentStatus.PENDING_REVIEW),
+      );
+    });
+
+    it('DEPLOYED → APPROVED', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.DEPLOYED, DocumentStatus.APPROVED),
+      );
+    });
+  });
+
+  describe('invalid transitions', () => {
+    it('PENDING_TRANSLATION → APPROVED (skip)', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.PENDING_TRANSLATION, DocumentStatus.APPROVED),
+        { message: /Invalid status transition/ },
+      );
+    });
+
+    it('PENDING_TRANSLATION → DEPLOYED (skip)', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.PENDING_TRANSLATION, DocumentStatus.DEPLOYED),
+        { message: /Invalid status transition/ },
+      );
+    });
+
+    it('DEPLOYED → IN_PROGRESS (skip backward)', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.DEPLOYED, DocumentStatus.IN_PROGRESS),
+        { message: /Invalid status transition/ },
+      );
+    });
+
+    it('DEPLOYED → PENDING_TRANSLATION (skip backward)', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.DEPLOYED, DocumentStatus.PENDING_TRANSLATION),
+        { message: /Invalid status transition/ },
+      );
+    });
+
+    it('same status is a no-op (throws)', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.IN_PROGRESS, DocumentStatus.IN_PROGRESS),
+        { message: /Invalid status transition/ },
+      );
+    });
+  });
+
+  describe('guards', () => {
+    it('cannot approve with open suggestions', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.APPROVED, { openSuggestionsCount: 3 }),
+        { message: /open suggestions/ },
+      );
+    });
+
+    it('cannot deploy with open suggestions', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.APPROVED, DocumentStatus.DEPLOYED, { openSuggestionsCount: 1 }),
+        { message: /open suggestions/ },
+      );
+    });
+
+    it('approve passes with zero open suggestions', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.APPROVED, { openSuggestionsCount: 0 }),
+      );
+    });
+
+    it('approve without context defaults to no guard check', () => {
+      assert.doesNotThrow(() =>
+        validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.APPROVED),
+      );
+    });
+  });
+});

--- a/src/domain/document-version/document-version.transitions.test.ts
+++ b/src/domain/document-version/document-version.transitions.test.ts
@@ -49,7 +49,7 @@ describe('validateTransition', () => {
       );
     });
 
-    it('DEPLOYED → APPROVED', () => {
+    it('DEPLOYED → APPROVED (no guard on backward transition)', () => {
       assert.doesNotThrow(() =>
         validateTransition(DocumentStatus.DEPLOYED, DocumentStatus.APPROVED),
       );
@@ -114,9 +114,10 @@ describe('validateTransition', () => {
       );
     });
 
-    it('approve without context defaults to no guard check', () => {
-      assert.doesNotThrow(() =>
-        validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.APPROVED),
+    it('approve without context throws (guard is mandatory)', () => {
+      assert.throws(
+        () => validateTransition(DocumentStatus.PENDING_REVIEW, DocumentStatus.APPROVED),
+        { message: /requires context/ },
       );
     });
   });

--- a/src/domain/document-version/document-version.transitions.ts
+++ b/src/domain/document-version/document-version.transitions.ts
@@ -2,7 +2,7 @@ import { DocumentStatus } from '@prisma/client';
 
 // ─── Valid transitions map ───────────────────────────────────
 
-const VALID_TRANSITIONS: Record<DocumentStatus, DocumentStatus[]> = {
+export const VALID_TRANSITIONS: Record<DocumentStatus, DocumentStatus[]> = {
   [DocumentStatus.PENDING_TRANSLATION]: [DocumentStatus.IN_PROGRESS],
   [DocumentStatus.IN_PROGRESS]: [DocumentStatus.PENDING_TRANSLATION, DocumentStatus.PENDING_REVIEW],
   [DocumentStatus.PENDING_REVIEW]: [DocumentStatus.IN_PROGRESS, DocumentStatus.APPROVED],

--- a/src/domain/document-version/document-version.transitions.ts
+++ b/src/domain/document-version/document-version.transitions.ts
@@ -1,7 +1,5 @@
 import { DocumentStatus } from '@prisma/client';
 
-// ─── Valid transitions map ───────────────────────────────────
-
 export const VALID_TRANSITIONS: Record<DocumentStatus, DocumentStatus[]> = {
   [DocumentStatus.PENDING_TRANSLATION]: [DocumentStatus.IN_PROGRESS],
   [DocumentStatus.IN_PROGRESS]: [DocumentStatus.PENDING_TRANSLATION, DocumentStatus.PENDING_REVIEW],
@@ -10,13 +8,20 @@ export const VALID_TRANSITIONS: Record<DocumentStatus, DocumentStatus[]> = {
   [DocumentStatus.DEPLOYED]: [DocumentStatus.APPROVED],
 };
 
-// ─── Transition context for guards ───────────────────────────
+const STATUS_ORDER: DocumentStatus[] = [
+  DocumentStatus.PENDING_TRANSLATION,
+  DocumentStatus.IN_PROGRESS,
+  DocumentStatus.PENDING_REVIEW,
+  DocumentStatus.APPROVED,
+  DocumentStatus.DEPLOYED,
+];
+
+// Guards only apply on forward transitions to these statuses
+const FORWARD_GUARDED_STATUSES: DocumentStatus[] = [DocumentStatus.APPROVED, DocumentStatus.DEPLOYED];
 
 export interface TransitionContext {
-  openSuggestionsCount?: number;
+  openSuggestionsCount: number;
 }
-
-// ─── Validation ──────────────────────────────────────────────
 
 export function validateTransition(
   from: DocumentStatus,
@@ -25,20 +30,23 @@ export function validateTransition(
 ): void {
   const allowed = VALID_TRANSITIONS[from];
 
-  if (!allowed || !allowed.includes(to)) {
+  if (!allowed.includes(to)) {
     throw new Error(
-      `Invalid status transition: ${from} → ${to}. Allowed transitions from ${from}: ${allowed?.join(', ') || 'none'}`,
+      `Invalid status transition: ${from} → ${to}. Allowed transitions from ${from}: ${allowed.join(', ')}`,
     );
   }
 
-  // Guards
-  if (
-    (to === DocumentStatus.APPROVED || to === DocumentStatus.DEPLOYED) &&
-    context?.openSuggestionsCount !== undefined &&
-    context.openSuggestionsCount > 0
-  ) {
-    throw new Error(
-      `Cannot transition to ${to}: there are ${context.openSuggestionsCount} open suggestions that must be resolved first`,
-    );
+  // Guards only apply on forward transitions (moving up the sequence)
+  const isForward = STATUS_ORDER.indexOf(to) > STATUS_ORDER.indexOf(from);
+
+  if (isForward && FORWARD_GUARDED_STATUSES.includes(to)) {
+    if (!context) {
+      throw new Error(`Transition to ${to} requires context with openSuggestionsCount`);
+    }
+    if (context.openSuggestionsCount > 0) {
+      throw new Error(
+        `Cannot transition to ${to}: there are ${context.openSuggestionsCount} open suggestions that must be resolved first`,
+      );
+    }
   }
 }

--- a/src/domain/document-version/document-version.transitions.ts
+++ b/src/domain/document-version/document-version.transitions.ts
@@ -1,0 +1,44 @@
+import { DocumentStatus } from '@prisma/client';
+
+// ─── Valid transitions map ───────────────────────────────────
+
+const VALID_TRANSITIONS: Record<DocumentStatus, DocumentStatus[]> = {
+  [DocumentStatus.PENDING_TRANSLATION]: [DocumentStatus.IN_PROGRESS],
+  [DocumentStatus.IN_PROGRESS]: [DocumentStatus.PENDING_TRANSLATION, DocumentStatus.PENDING_REVIEW],
+  [DocumentStatus.PENDING_REVIEW]: [DocumentStatus.IN_PROGRESS, DocumentStatus.APPROVED],
+  [DocumentStatus.APPROVED]: [DocumentStatus.PENDING_REVIEW, DocumentStatus.DEPLOYED],
+  [DocumentStatus.DEPLOYED]: [DocumentStatus.APPROVED],
+};
+
+// ─── Transition context for guards ───────────────────────────
+
+export interface TransitionContext {
+  openSuggestionsCount?: number;
+}
+
+// ─── Validation ──────────────────────────────────────────────
+
+export function validateTransition(
+  from: DocumentStatus,
+  to: DocumentStatus,
+  context?: TransitionContext,
+): void {
+  const allowed = VALID_TRANSITIONS[from];
+
+  if (!allowed || !allowed.includes(to)) {
+    throw new Error(
+      `Invalid status transition: ${from} → ${to}. Allowed transitions from ${from}: ${allowed?.join(', ') || 'none'}`,
+    );
+  }
+
+  // Guards
+  if (
+    (to === DocumentStatus.APPROVED || to === DocumentStatus.DEPLOYED) &&
+    context?.openSuggestionsCount !== undefined &&
+    context.openSuggestionsCount > 0
+  ) {
+    throw new Error(
+      `Cannot transition to ${to}: there are ${context.openSuggestionsCount} open suggestions that must be resolved first`,
+    );
+  }
+}

--- a/src/domain/suggestion/suggestion.repository.ts
+++ b/src/domain/suggestion/suggestion.repository.ts
@@ -147,6 +147,15 @@ export async function getSuggestionReplyById(id: string) {
   });
 }
 
+export async function countOpenSuggestions(documentVersionId: string): Promise<number> {
+  return prisma.suggestion.count({
+    where: {
+      documentVersionId,
+      status: SuggestionStatus.OPEN,
+    },
+  });
+}
+
 export async function checkSuggestionConflict(suggestionId: string, currentContent: string) {
   const suggestion = await getSuggestionById(suggestionId);
   if (!suggestion) {


### PR DESCRIPTION
## Summary

- Add pure domain module `document-version.transitions.ts` with valid transitions map and `validateTransition()` function
- Wire validation into all 4 status-changing server actions (submitForReview, reviewVersion, deployVersion, updateDocumentVersionStatus)
- Enforce open suggestions guard server-side for forward transitions to APPROVED/DEPLOYED
- Remove implicit auto-transitions from repository (versions always start as PENDING_TRANSLATION)
- Update StatusDropdown to use shared transitions map (single source of truth)
- 17 tests covering all valid/invalid transitions and guards

**Key design decisions:**
- Guards only apply on **forward** transitions — backward transitions (e.g., DEPLOYED → APPROVED) skip the suggestions check since open suggestions may be explanations for the rollback
- `assignDocumentVersionAction` intentionally bypasses validation (special "Start Translation" flow)
- Context with `openSuggestionsCount` is mandatory for forward APPROVED/DEPLOYED transitions — can't accidentally skip the guard

## Related issues

Closes #12 (PRD), closes #13, closes #14, closes #15, closes #16

## Test plan

- [x] 17 unit tests for `validateTransition()` — all pass
- [x] Verify "Start translation" button works (PENDING_TRANSLATION → IN_PROGRESS)
- [x] Verify submit for review flow (IN_PROGRESS → PENDING_REVIEW)
- [x] Verify approve/reject flow (PENDING_REVIEW → APPROVED / IN_PROGRESS)
- [x] Verify deploy flow (APPROVED → DEPLOYED)
- [x] Verify backward transitions work (e.g., DEPLOYED → APPROVED)
- [x] Verify can't approve with open suggestions (server-side + UI warning)
- [x] Verify StatusDropdown shows same options as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)