### PR TITLE
Extract resolveTranslationProject utility + fix reply input focus

### DIFF
--- a/src/app/documents/[id]/review/page.client.tsx
+++ b/src/app/documents/[id]/review/page.client.tsx
@@ -147,10 +147,11 @@ function ReviewInner({
     }
   }, [initialActivityLogs]);
 
-  // Refresh suggestions when content changes
+  // Refresh suggestions when the version changes (not on every content change,
+  // which would cause focus loss in reply inputs due to list re-rendering)
   useEffect(() => {
     reloadSuggestions();
-  }, [targetVersion?.id, content, reloadSuggestions]);
+  }, [targetVersion?.id, reloadSuggestions]);
 
   // ─── Derived values ─────────────────────────────────────
   const canEditSourceBase = isAdminClient(user);

--- a/src/components/source-translation-viewer.tsx
+++ b/src/components/source-translation-viewer.tsx
@@ -280,7 +280,6 @@ export const SourceTranslationViewer = forwardRef<SourceTranslationViewerHandle,
             );
             editor.revealRangeInCenter(range);
             editor.setSelection(range);
-            editor.focus();
           }
 
           // Always sync both panes for context

--- a/src/components/textarea-with-line-numbers.tsx
+++ b/src/components/textarea-with-line-numbers.tsx
@@ -68,6 +68,10 @@ export const TextareaWithLineNumbers = forwardRef<any, TextareaWithLineNumbersPr
       return;
     }
 
+    // Only move cursor if the editor currently has focus — otherwise
+    // setPosition steals focus from other inputs (e.g. reply input)
+    if (!editor.hasTextFocus()) return;
+
     // Set cursor position to the highlighted line
     // This will trigger Monaco's native blue line highlight
     ignoreNextCursorEventRef.current = true;

--- a/src/domain/document-version/document-version.actions.ts
+++ b/src/domain/document-version/document-version.actions.ts
@@ -8,6 +8,7 @@ import { coalesceEditLog, createActivityLog } from '../activity-log/activity-log
 import { createComment } from '../comment/comment.repository';
 import { countOpenSuggestions } from '../suggestion/suggestion.repository';
 import { validateTransition } from './document-version.transitions';
+import { resolveTranslationProject } from './resolve-translation-project';
 import { getDocumentAssignmentByDocumentAndProject } from '../document-assignment/document-assignment.repository';
 import { getDocumentById } from '../document/document.repository';
 import { getLanguageById } from '../language/language.repository';
@@ -197,24 +198,7 @@ export async function reviewVersionAction(input: unknown) {
   const { user } = await authorize('authenticated');
   const validated = reviewVersionSchema.parse(input);
 
-  // Get current version to check if it has content
-  const currentVersion = await getDocumentVersionById(validated.versionId);
-
-  if (!currentVersion) {
-    throw new Error('Document version not found');
-  }
-
-  // Get document to find source project
-  const document = await getDocumentById(currentVersion.documentId);
-  if (!document || !document.sourceProjectId) {
-    throw new Error('Document not found or not associated with a source project');
-  }
-
-  // Get translation project
-  const translationProject = await getTranslationProjectBySourceAndLanguage(
-    document.sourceProjectId,
-    currentVersion.languageId,
-  );
+  const { version: currentVersion, translationProject } = await resolveTranslationProject(validated.versionId);
 
   if (translationProject) {
     await authorize({ project: translationProject.id, role: 'reviewer' });

--- a/src/domain/document-version/resolve-translation-project.ts
+++ b/src/domain/document-version/resolve-translation-project.ts
@@ -1,0 +1,26 @@
+import { getDocumentById } from '../document/document.repository';
+import { getDocumentVersionById } from './document-version.repository';
+import { getTranslationProjectBySourceAndLanguage } from '../translation-project/translation-project.repository';
+
+/**
+ * Resolves the full context (version, document, translation project) from a documentVersionId.
+ * Used by actions that need to check project-scoped permissions before operating on a version.
+ */
+export async function resolveTranslationProject(documentVersionId: string) {
+  const version = await getDocumentVersionById(documentVersionId);
+  if (!version) {
+    throw new Error('Document version not found');
+  }
+
+  const document = await getDocumentById(version.documentId);
+  if (!document || !document.sourceProjectId) {
+    throw new Error('Document not found or not associated with a source project');
+  }
+
+  const translationProject = await getTranslationProjectBySourceAndLanguage(
+    document.sourceProjectId,
+    version.languageId,
+  );
+
+  return { version, document, translationProject };
+}

--- a/src/domain/suggestion/suggestion.actions.ts
+++ b/src/domain/suggestion/suggestion.actions.ts
@@ -4,9 +4,8 @@ import { authorize } from '@/lib/authorize';
 import { SuggestionStatus, SuggestionType } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 import { createActivityLog } from '../activity-log/activity-log.repository';
-import { getDocumentById } from '../document/document.repository';
 import { getDocumentVersionById, updateDocumentVersion } from '../document-version/document-version.repository';
-import { getTranslationProjectBySourceAndLanguage } from '../translation-project/translation-project.repository';
+import { resolveTranslationProject } from '../document-version/resolve-translation-project';
 import {
   applySuggestionSchema,
   createSuggestionReplySchema,
@@ -47,23 +46,7 @@ export async function createSuggestionAction(input: unknown) {
   const { user } = await authorize('authenticated');
   const validated = createSuggestionSchema.parse(input);
 
-  // Get document version to check permissions
-  const documentVersion = await getDocumentVersionById(validated.documentVersionId);
-  if (!documentVersion) {
-    throw new Error('Document version not found');
-  }
-
-  // Get document to find source project
-  const document = await getDocumentById(documentVersion.documentId);
-  if (!document || !document.sourceProjectId) {
-    throw new Error('Document not found or not associated with a source project');
-  }
-
-  // Get translation project
-  const translationProject = await getTranslationProjectBySourceAndLanguage(
-    document.sourceProjectId,
-    documentVersion.languageId,
-  );
+  const { version: documentVersion, translationProject } = await resolveTranslationProject(validated.documentVersionId);
 
   if (translationProject) {
     await authorize({ project: translationProject.id, role: 'reviewer' });
@@ -141,23 +124,7 @@ export async function applySuggestionAction(input: unknown) {
     throw new Error('Cannot apply a suggestion without a text range');
   }
 
-  // Get document version
-  const documentVersion = await getDocumentVersionById(suggestion.documentVersionId);
-  if (!documentVersion) {
-    throw new Error('Document version not found');
-  }
-
-  // Get document to find source project
-  const document = await getDocumentById(documentVersion.documentId);
-  if (!document || !document.sourceProjectId) {
-    throw new Error('Document not found or not associated with a source project');
-  }
-
-  // Get translation project
-  const translationProject = await getTranslationProjectBySourceAndLanguage(
-    document.sourceProjectId,
-    documentVersion.languageId,
-  );
+  const { version: documentVersion, translationProject } = await resolveTranslationProject(suggestion.documentVersionId);
 
   if (translationProject) {
     await authorize({ project: translationProject.id, role: 'translator' });
@@ -249,23 +216,7 @@ export async function dismissSuggestionAction(input: unknown) {
     throw new Error('Only open suggestions can be dismissed');
   }
 
-  // Get document version
-  const documentVersion = await getDocumentVersionById(suggestion.documentVersionId);
-  if (!documentVersion) {
-    throw new Error('Document version not found');
-  }
-
-  // Get document to find source project
-  const document = await getDocumentById(documentVersion.documentId);
-  if (!document || !document.sourceProjectId) {
-    throw new Error('Document not found or not associated with a source project');
-  }
-
-  // Get translation project
-  const translationProject = await getTranslationProjectBySourceAndLanguage(
-    document.sourceProjectId,
-    documentVersion.languageId,
-  );
+  const { version: documentVersion, translationProject } = await resolveTranslationProject(suggestion.documentVersionId);
 
   if (translationProject) {
     await authorize({ project: translationProject.id, role: 'translator' });
@@ -311,21 +262,7 @@ export async function reopenSuggestionAction(input: unknown) {
     throw new Error('Suggestion is already open');
   }
 
-  // Get document version to check permissions
-  const documentVersion = await getDocumentVersionById(suggestion.documentVersionId);
-  if (!documentVersion) {
-    throw new Error('Document version not found');
-  }
-
-  const document = await getDocumentById(documentVersion.documentId);
-  if (!document || !document.sourceProjectId) {
-    throw new Error('Document not found or not associated with a source project');
-  }
-
-  const translationProject = await getTranslationProjectBySourceAndLanguage(
-    document.sourceProjectId,
-    documentVersion.languageId,
-  );
+  const { version: documentVersion, translationProject } = await resolveTranslationProject(suggestion.documentVersionId);
 
   if (translationProject) {
     await authorize({ project: translationProject.id, roles: ['reviewer', 'translator'] });


### PR DESCRIPTION
## Summary

- Extract the 3-step version→document→project lookup chain into `resolveTranslationProject()` utility
- Replaces ~10 lines of duplicated code in 5 action functions
- Fix Monaco editor stealing focus from reply input when clicking thread cards
- Fix Monaco `setPosition` stealing focus from sidebar inputs on `highlightLine` changes
- Remove `content` from `reloadSuggestions` useEffect dependency (was causing unnecessary reloads)

## Test plan

- [x] App builds with no type errors
- [x] Reply input holds focus when clicking into it
- [x] Clicking thread card highlights text in editor without stealing focus
- [ ] Create/apply/dismiss/reopen suggestions still work
- [ ] Review version (approve/reject) still works

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)