### PR TITLE
feat: invitation model, token validation, and registration page

### DIFF
--- a/prisma/migrations/20260327000000_add_invitation_model/migration.sql
+++ b/prisma/migrations/20260327000000_add_invitation_model/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "InvitationStatus" AS ENUM ('ACTIVE', 'REVOKED');
+
+-- CreateTable
+CREATE TABLE "invitation" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "maxUses" INTEGER,
+    "usedCount" INTEGER NOT NULL DEFAULT 0,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "status" "InvitationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "invitation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "invitation_token_key" ON "invitation"("token");
+
+-- AddForeignKey
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,11 @@ enum Role {
   ADMIN
 }
 
+enum InvitationStatus {
+  ACTIVE
+  REVOKED
+}
+
 enum ProjectRole {
   PROJECT_MANAGER
   REVIEWER
@@ -86,6 +91,7 @@ model User {
   languages           UserLanguage[]
   suggestions         Suggestion[]
   suggestionReplies   SuggestionReply[]
+  invitationsCreated  Invitation[]     @relation("InvitationsCreated")
 
   @@map("user")
 }
@@ -369,4 +375,19 @@ model GitHubCommit {
   updatedAt         DateTime        @updatedAt
 
   @@map("github_commit")
+}
+
+model Invitation {
+  id          String           @id @default(uuid())
+  token       String           @unique
+  maxUses     Int?             // null = unlimited, 1 = single-use, N = max registrations
+  usedCount   Int              @default(0)
+  expiresAt   DateTime
+  status      InvitationStatus @default(ACTIVE)
+  createdById String
+  createdBy   User             @relation("InvitationsCreated", fields: [createdById], references: [id], onDelete: Cascade)
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  @@map("invitation")
 }

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,18 @@
 import { auth } from '@/lib/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
+import { NextRequest, NextResponse } from 'next/server';
 
-export const { GET, POST } = toNextJsHandler(auth.handler);
+const betterAuthHandler = toNextJsHandler(auth.handler);
+
+export const GET = betterAuthHandler.GET;
+
+export async function POST(request: NextRequest) {
+  // Block direct signup — registration must go through invitation flow
+  if (request.nextUrl.pathname === '/api/auth/sign-up/email') {
+    return NextResponse.json(
+      { error: 'Registration is by invitation only' },
+      { status: 403 },
+    );
+  }
+  return betterAuthHandler.POST(request);
+}

--- a/src/app/register/[token]/page.client.tsx
+++ b/src/app/register/[token]/page.client.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { registerWithInviteAction } from '@/domain/invitation/invitation.actions';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+type ValidationResult =
+  | { valid: true; inviterName: string }
+  | { valid: false; reason: string };
+
+interface RegisterClientProps {
+  token: string;
+  validation: ValidationResult;
+}
+
+export default function RegisterClient({ token, validation }: RegisterClientProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  if (!validation.valid) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <Card className="w-full max-w-md p-6 text-center">
+          <h1 className="text-2xl font-bold mb-2">Invalid Invitation</h1>
+          <p className="text-gray-600 mb-4">{validation.reason}</p>
+          <p className="text-sm text-gray-500 mb-4">
+            Please contact your administrator for a new invitation link.
+          </p>
+          <Link href="/login">
+            <Button variant="outline">Go to Login</Button>
+          </Link>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      await registerWithInviteAction({ token, name, email, password });
+      router.push('/onboarding/languages');
+    } catch (error: any) {
+      console.error('Register error:', error);
+      toast.error(error.message || 'Failed to register');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <Card className="w-full max-w-md p-4">
+        <div className="text-center mb-4">
+          <h1 className="text-2xl font-bold">Translation Helper</h1>
+          <p className="text-gray-600">
+            You were invited by {validation.inviterName}
+          </p>
+        </div>
+
+        <form onSubmit={handleRegister} className="space-y-4">
+          <div>
+            <Label htmlFor="register-name">Name</Label>
+            <Input
+              id="register-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="Your name"
+            />
+          </div>
+          <div>
+            <Label htmlFor="register-email">Email</Label>
+            <Input
+              id="register-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder="your@email.com"
+            />
+          </div>
+          <div>
+            <Label htmlFor="register-password">Password</Label>
+            <Input
+              id="register-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              placeholder="••••••••"
+              minLength={8}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Creating account...' : 'Create Account'}
+          </Button>
+        </form>
+
+        <p className="text-center text-sm text-gray-500 mt-4">
+          Already have an account?{' '}
+          <Link href="/login" className="text-blue-600 hover:underline">
+            Login
+          </Link>
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/register/[token]/page.tsx
+++ b/src/app/register/[token]/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation';
+import { getCurrentUser } from '@/lib/session';
+import { validateInvitationTokenAction } from '@/domain/invitation/invitation.actions';
+import RegisterClient from './page.client';
+
+interface RegisterPageProps {
+  params: Promise<{ token: string }>;
+}
+
+export default async function RegisterPage({ params }: RegisterPageProps) {
+  const user = await getCurrentUser();
+  if (user) {
+    redirect('/dashboard');
+  }
+
+  const { token } = await params;
+  const validation = await validateInvitationTokenAction(token);
+
+  return <RegisterClient token={token} validation={validation} />;
+}

--- a/src/domain/invitation/invitation.actions.ts
+++ b/src/domain/invitation/invitation.actions.ts
@@ -1,0 +1,97 @@
+'use server';
+
+import crypto from 'node:crypto';
+import { authorize } from '@/lib/authorize';
+import { auth } from '@/lib/auth';
+import { createInvitationSchema, registerWithInviteSchema } from './invitation.types';
+import {
+  createInvitation,
+  findInvitationByToken,
+  incrementUsedCount,
+  rollbackInvitationUse,
+  listInvitations,
+  revokeInvitation,
+} from './invitation.repository';
+import { validateInvitationToken } from './invitation.validation';
+
+const DEFAULT_EXPIRY_DAYS = 30;
+
+export async function createInvitationAction(input: unknown) {
+  const { user } = await authorize('admin');
+  const parsed = createInvitationSchema.parse(input);
+
+  const token = crypto.randomUUID();
+  const expiresAt = parsed.expiresAt ?? new Date(Date.now() + DEFAULT_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+
+  const invitation = await createInvitation(token, parsed.maxUses ?? null, expiresAt, user.id);
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const inviteUrl = `${baseUrl}/register/${invitation.token}`;
+
+  return { ...invitation, inviteUrl };
+}
+
+export async function listInvitationsAction() {
+  await authorize('admin');
+  return listInvitations();
+}
+
+export async function validateInvitationTokenAction(token: string): Promise<
+  | { valid: true; inviterName: string }
+  | { valid: false; reason: string }
+> {
+  const invitation = await findInvitationByToken(token);
+  const result = validateInvitationToken(invitation);
+
+  if (!result.valid) {
+    return result;
+  }
+
+  return {
+    valid: true,
+    inviterName: invitation!.createdBy.name,
+  };
+}
+
+export async function revokeInvitationAction(id: string) {
+  await authorize('admin');
+  return revokeInvitation(id);
+}
+
+export async function registerWithInviteAction(input: unknown) {
+  const parsed = registerWithInviteSchema.parse(input);
+
+  // 1. Find and validate the invitation
+  const invitation = await findInvitationByToken(parsed.token);
+  const validation = validateInvitationToken(invitation);
+
+  if (!validation.valid) {
+    throw new Error(validation.reason);
+  }
+
+  // 2. Consume atomically FIRST — fails fast if already used
+  const consumed = await incrementUsedCount(invitation!.id);
+  if (!consumed) {
+    throw new Error('Invitation has already been used');
+  }
+
+  // 3. Create user — rollback invitation consumption on failure
+  try {
+    const signUpResult = await auth.api.signUpEmail({
+      body: {
+        email: parsed.email,
+        password: parsed.password,
+        name: parsed.name,
+      },
+    });
+
+    if (!signUpResult?.user) {
+      throw new Error('Failed to create account');
+    }
+  } catch (error) {
+    await rollbackInvitationUse(invitation!.id);
+    throw error;
+  }
+
+  return { success: true };
+}

--- a/src/domain/invitation/invitation.repository.ts
+++ b/src/domain/invitation/invitation.repository.ts
@@ -1,0 +1,77 @@
+import prisma from '@/lib/db';
+import type { InvitationStatus } from '@prisma/client';
+
+export async function createInvitation(
+  token: string,
+  maxUses: number | null,
+  expiresAt: Date,
+  createdById: string,
+) {
+  return prisma.invitation.create({
+    data: { token, maxUses, expiresAt, createdById },
+    select: {
+      id: true,
+      token: true,
+      maxUses: true,
+      expiresAt: true,
+      createdAt: true,
+    },
+  });
+}
+
+export async function findInvitationByToken(token: string) {
+  return prisma.invitation.findUnique({
+    where: { token },
+    include: {
+      createdBy: {
+        select: { id: true, name: true, email: true },
+      },
+    },
+  });
+}
+
+/**
+ * Atomically consume one use of an invitation.
+ * Checks status, expiry, AND usedCount < maxUses in a single UPDATE.
+ * null maxUses = unlimited uses.
+ */
+export async function incrementUsedCount(id: string): Promise<boolean> {
+  const result = await prisma.$executeRaw`
+    UPDATE invitation
+    SET "usedCount" = "usedCount" + 1, "updatedAt" = NOW()
+    WHERE id = ${id}
+      AND status = 'ACTIVE'
+      AND "expiresAt" > NOW()
+      AND ("maxUses" IS NULL OR "usedCount" < "maxUses")
+  `;
+  return result > 0;
+}
+
+/**
+ * Rollback a consumed invitation use (e.g. if user creation fails after consumption).
+ */
+export async function rollbackInvitationUse(id: string): Promise<void> {
+  await prisma.invitation.updateMany({
+    where: { id, usedCount: { gt: 0 } },
+    data: { usedCount: { decrement: 1 } },
+  });
+}
+
+export async function listInvitations() {
+  return prisma.invitation.findMany({
+    include: {
+      createdBy: {
+        select: { id: true, name: true, email: true },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function revokeInvitation(id: string) {
+  return prisma.invitation.update({
+    where: { id },
+    data: { status: 'REVOKED' as InvitationStatus },
+    select: { id: true, status: true },
+  });
+}

--- a/src/domain/invitation/invitation.types.ts
+++ b/src/domain/invitation/invitation.types.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const createInvitationSchema = z.object({
+  maxUses: z.number().int().min(1).nullable().optional().default(null),
+  expiresAt: z.coerce.date().optional(),
+});
+
+export const registerWithInviteSchema = z.object({
+  token: z.string().min(1),
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+export type CreateInvitationInput = z.infer<typeof createInvitationSchema>;
+export type RegisterWithInviteInput = z.infer<typeof registerWithInviteSchema>;

--- a/src/domain/invitation/invitation.validation.test.ts
+++ b/src/domain/invitation/invitation.validation.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateInvitationToken, type InvitationForValidation } from './invitation.validation';
+
+// ─── Test fixtures ───────────────────────────────────────────
+
+function createInvitation(overrides: Partial<InvitationForValidation> = {}): InvitationForValidation {
+  return {
+    status: 'ACTIVE',
+    expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24), // 24h from now
+    usedCount: 0,
+    maxUses: null, // unlimited
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────
+
+describe('validateInvitationToken', () => {
+  it('returns valid for a fresh unlimited invitation', () => {
+    const result = validateInvitationToken(createInvitation());
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid for an unlimited invitation with many uses', () => {
+    const result = validateInvitationToken(createInvitation({ usedCount: 9999 }));
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid for a fresh single-use invitation', () => {
+    const result = validateInvitationToken(createInvitation({ maxUses: 1 }));
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid for a fresh multi-use invitation', () => {
+    const result = validateInvitationToken(createInvitation({ maxUses: 10 }));
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns valid for a partially used multi-use invitation', () => {
+    const result = validateInvitationToken(createInvitation({ maxUses: 5, usedCount: 3 }));
+    assert.deepStrictEqual(result, { valid: true });
+  });
+
+  it('returns invalid when invitation is null', () => {
+    const result = validateInvitationToken(null);
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation not found' });
+  });
+
+  it('returns invalid when invitation is revoked', () => {
+    const result = validateInvitationToken(createInvitation({ status: 'REVOKED' }));
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation has been revoked' });
+  });
+
+  it('returns invalid when invitation has expired', () => {
+    const result = validateInvitationToken(createInvitation({
+      expiresAt: new Date(Date.now() - 1000), // 1s ago
+    }));
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation has expired' });
+  });
+
+  it('returns invalid when single-use invitation is exhausted', () => {
+    const result = validateInvitationToken(createInvitation({ maxUses: 1, usedCount: 1 }));
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation has already been used' });
+  });
+
+  it('returns invalid when multi-use invitation is fully used', () => {
+    const result = validateInvitationToken(createInvitation({ maxUses: 3, usedCount: 3 }));
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation has already been used' });
+  });
+
+  it('checks revoked before expired', () => {
+    const result = validateInvitationToken(createInvitation({
+      status: 'REVOKED',
+      expiresAt: new Date(Date.now() - 1000),
+    }));
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation has been revoked' });
+  });
+
+  it('checks expired before used', () => {
+    const result = validateInvitationToken(createInvitation({
+      maxUses: 1,
+      expiresAt: new Date(Date.now() - 1000),
+      usedCount: 1,
+    }));
+    assert.deepStrictEqual(result, { valid: false, reason: 'Invitation has expired' });
+  });
+});

--- a/src/domain/invitation/invitation.validation.ts
+++ b/src/domain/invitation/invitation.validation.ts
@@ -1,0 +1,35 @@
+import type { InvitationStatus } from '@prisma/client';
+
+export interface InvitationForValidation {
+  status: InvitationStatus;
+  expiresAt: Date;
+  usedCount: number;
+  maxUses: number | null;
+}
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export function validateInvitationToken(
+  invitation: InvitationForValidation | null,
+): ValidationResult {
+  if (!invitation) {
+    return { valid: false, reason: 'Invitation not found' };
+  }
+
+  if (invitation.status !== 'ACTIVE') {
+    return { valid: false, reason: 'Invitation has been revoked' };
+  }
+
+  if (invitation.expiresAt <= new Date()) {
+    return { valid: false, reason: 'Invitation has expired' };
+  }
+
+  // null = unlimited uses, number = capped
+  if (invitation.maxUses !== null && invitation.usedCount >= invitation.maxUses) {
+    return { valid: false, reason: 'Invitation has already been used' };
+  }
+
+  return { valid: true };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,7 +30,7 @@ export async function proxy(request: NextRequest) {
   }
 
   // If accessing public auth pages with session cookie, redirect to dashboard
-  if ((pathname === '/login' || pathname === '/register') && sessionCookie) {
+  if ((pathname === '/login' || pathname.startsWith('/register')) && sessionCookie) {
     return NextResponse.redirect(new URL('/dashboard', request.url));
   }
 


### PR DESCRIPTION
## Summary

Implements invite-only registration system (closes #26, parent PRD #24).

- **Invitation Prisma model** with token, maxUses (null=unlimited, 1=single-use, N=capped), expiry, and ACTIVE/REVOKED status
- **Pure validation function** with 12-test suite covering all edge cases (expired, revoked, exhausted, unlimited, etc.)
- **Domain module** following existing patterns: types, repository (with raw SQL atomic consumption), validation, server actions
- **`/register/[token]` page** — validates token server-side, shows inviter name, registration form, redirects to onboarding
- **Direct signup blocked** — POST to `/api/auth/sign-up/email` returns 403; server-side `auth.api.signUpEmail()` still works for the invitation flow
- **Race condition safe** — invitation consumed atomically before user creation, with rollback on failure

## Test plan

- [x] Visit `/register/<valid-token>` → see inviter name + registration form
- [x] Register → redirects to `/onboarding/languages`
- [x] Reuse single-use token → "already been used" error
- [x] Visit `/register/<invalid-token>` → "not found" error
- [x] Expired invitation → "expired" error
- [x] Revoked invitation → "revoked" error
- [x] Unlimited invitation (maxUses=null) → works repeatedly
- [x] `curl -X POST /api/auth/sign-up/email` → 403
- [x] Login flow at `/login` still works
- [x] `npx tsx --test src/domain/invitation/invitation.validation.test.ts` → 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)