### PR TITLE
feat: make user and reviewer fields optional in DocumentVersion model

### DIFF
--- a/prisma/migrations/20260408132612_make_document_version_user_optional/migration.sql
+++ b/prisma/migrations/20260408132612_make_document_version_user_optional/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "document_version" DROP CONSTRAINT "document_version_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "document_version" ALTER COLUMN "userId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "document_version" ADD CONSTRAINT "document_version_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260408133800_migrate_comments_to_suggestions/migration.sql
+++ b/prisma/migrations/20260408133800_migrate_comments_to_suggestions/migration.sql
@@ -1,0 +1,38 @@
+-- Migrate all comments to general (unanchored) suggestions
+INSERT INTO "suggestion" (
+  "id",
+  "documentVersionId",
+  "userId",
+  "comment",
+  "startLine",
+  "startColumn",
+  "endLine",
+  "endColumn",
+  "type",
+  "proposedText",
+  "originalText",
+  "status",
+  "dismissedReason",
+  "version",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  gen_random_uuid(),
+  c."documentVersionId",
+  c."userId",
+  c."content",
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  'COMMENT',
+  NULL,
+  NULL,
+  'OPEN',
+  NULL,
+  dv."version",
+  c."createdAt",
+  c."updatedAt"
+FROM "comment" c
+JOIN "document_version" dv ON c."documentVersionId" = dv."id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,8 +253,8 @@ model DocumentVersion {
   content      String         @db.Text // Markdown content
   status       DocumentStatus @default(PENDING_TRANSLATION)
   version      Int            @default(1)
-  userId       String
-  user         User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String?
+  user         User?          @relation(fields: [userId], references: [id], onDelete: SetNull)
   reviewerId   String?
   reviewer     User?          @relation("ReviewedBy", fields: [reviewerId], references: [id], onDelete: SetNull)
   createdAt    DateTime       @default(now())

--- a/src/app/dashboard/page.client.tsx
+++ b/src/app/dashboard/page.client.tsx
@@ -71,9 +71,9 @@ interface DashboardClientProps {
         name: string;
         code: string;
       };
-      _count: {
-        members: number;
-      };
+      members: {
+        userId: string;
+      }[];
     }[];
   }[];
   assignments: {

--- a/src/app/documents/[id]/review/page.client.tsx
+++ b/src/app/documents/[id]/review/page.client.tsx
@@ -402,32 +402,16 @@ function ReviewInner({
                 reviewer={targetVersion?.reviewer}
                 language={targetVersion?.language?.name}
                 onAssignTranslator={
-                  isAdminClient(user) &&
-                  translationProjectId &&
-                  (targetVersion?.status === DocumentStatus.PENDING_TRANSLATION || !targetVersion?.user)
-                    ? openAssignTranslatorDialog
-                    : undefined
+                  isAdminClient(user) && translationProjectId ? openAssignTranslatorDialog : undefined
                 }
                 onUnassignTranslator={
-                  isAdminClient(user) &&
-                  targetVersion?.user &&
-                  targetVersion?.status === DocumentStatus.PENDING_TRANSLATION
-                    ? unassignTranslator
-                    : undefined
+                  isAdminClient(user) && targetVersion?.user ? unassignTranslator : undefined
                 }
                 onAssignReviewer={
-                  isAdminClient(user) &&
-                  translationProjectId &&
-                  (targetVersion?.status === DocumentStatus.PENDING_TRANSLATION || !targetVersion?.reviewer)
-                    ? openAssignReviewerDialog
-                    : undefined
+                  isAdminClient(user) && translationProjectId ? openAssignReviewerDialog : undefined
                 }
                 onUnassignReviewer={
-                  isAdminClient(user) &&
-                  targetVersion?.reviewer &&
-                  targetVersion?.status === DocumentStatus.PENDING_TRANSLATION
-                    ? unassignReviewer
-                    : undefined
+                  isAdminClient(user) && targetVersion?.reviewer ? unassignReviewer : undefined
                 }
               />
             }

--- a/src/app/documents/[id]/translate/page.client.tsx
+++ b/src/app/documents/[id]/translate/page.client.tsx
@@ -584,43 +584,28 @@ function TranslateInner({
             onCreateGeneralThread={createGeneralThread}
             documentVersion={targetVersion?.version ?? 1}
             sidebarHeader={
-              targetVersion && (
-                <DocumentInfoCard
-                  status={targetVersion.status}
-                  translator={targetVersion.user}
-                  reviewer={targetVersion.reviewer || reviewer}
-                  language={targetVersion.language?.name}
-                  onAssignTranslator={
-                    isAdminClient(user) &&
-                    translationProject &&
-                    (targetVersion.status === DocumentStatus.PENDING_TRANSLATION || !targetVersion.user)
-                      ? openAssignTranslatorDialog
-                      : undefined
-                  }
-                  onUnassignTranslator={
-                    isAdminClient(user) &&
-                    assignment?.id &&
-                    targetVersion.user &&
-                    targetVersion.status === DocumentStatus.PENDING_TRANSLATION
-                      ? unassignTranslator
-                      : undefined
-                  }
-                  onAssignReviewer={
-                    isAdminClient(user) &&
-                    translationProject &&
-                    targetVersion.status === DocumentStatus.PENDING_TRANSLATION
-                      ? openAssignReviewerDialog
-                      : undefined
-                  }
-                  onUnassignReviewer={
-                    isAdminClient(user) &&
-                    targetVersion.reviewer &&
-                    targetVersion.status === DocumentStatus.PENDING_TRANSLATION
-                      ? unassignReviewer
-                      : undefined
-                  }
-                />
-              )
+              <DocumentInfoCard
+                status={targetVersion?.status ?? DocumentStatus.PENDING_TRANSLATION}
+                translator={targetVersion?.user ?? null}
+                reviewer={targetVersion?.reviewer || reviewer}
+                language={targetVersion?.language?.name}
+                onAssignTranslator={
+                  isAdminClient(user) && translationProject && targetVersion
+                    ? openAssignTranslatorDialog
+                    : undefined
+                }
+                onUnassignTranslator={
+                  isAdminClient(user) && targetVersion?.user ? unassignTranslator : undefined
+                }
+                onAssignReviewer={
+                  isAdminClient(user) && translationProject && targetVersion
+                    ? openAssignReviewerDialog
+                    : undefined
+                }
+                onUnassignReviewer={
+                  isAdminClient(user) && targetVersion?.reviewer ? unassignReviewer : undefined
+                }
+              />
             }
           />
         </div>

--- a/src/app/documents/page.client.tsx
+++ b/src/app/documents/page.client.tsx
@@ -37,7 +37,7 @@ type DocumentWithVersions = Document & {
       id: string;
       name: string;
       email: string;
-    };
+    } | null;
     updatedAt: Date;
   }>;
 };

--- a/src/app/projects/[sourceProjectId]/translations/[translationProjectId]/page.client.tsx
+++ b/src/app/projects/[sourceProjectId]/translations/[translationProjectId]/page.client.tsx
@@ -244,6 +244,7 @@ export default function TranslationProjectClient({
       setAssignmentDialogOpen(false);
       resetAssignmentForm();
       router.refresh();
+      toast.success('Document assigned!');
     } catch (error: any) {
       console.error('Error assigning document:', error);
       toast.error(error.message || 'Failed to assign document');
@@ -261,6 +262,7 @@ export default function TranslationProjectClient({
       });
       setAssignments(assignments.map((a) => (a.id === updated.id ? (updated as (typeof assignments)[0]) : a)));
       router.refresh();
+      toast.success(userId ? 'Assignment updated!' : 'Translator unassigned');
     } catch (error: any) {
       console.error('Error updating assignment:', error);
       toast.error(error.message || 'Failed to update assignment');

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -22,15 +22,16 @@ interface ProjectCardProps {
         name: string;
         code: string;
       };
-      _count: {
-        members: number;
-      };
+      members: {
+        userId: string;
+      }[];
     }[];
   };
 }
 
 export default function ProjectCard({ project }: ProjectCardProps) {
-  const totalMembers = project.translationProjects.reduce((sum, tp) => sum + tp._count.members, 0);
+  const uniqueUserIds = new Set(project.translationProjects.flatMap((tp) => tp.members.map((m) => m.userId)));
+  const totalMembers = uniqueUserIds.size;
 
   return (
     <Link href={`/projects/${project.id}`}>
@@ -64,12 +65,20 @@ export default function ProjectCard({ project }: ProjectCardProps) {
             )}
           </div>
           {project.translationProjects.length > 0 && (
-            <div className="flex flex-wrap gap-1 mt-3">
-              {project.translationProjects.map((tp) => (
-                <Badge key={tp.id} variant="secondary" size="xs">
-                  {tp.language.name}
-                </Badge>
-              ))}
+            <div className="flex flex-wrap gap-1.5 mt-3">
+              {project.translationProjects.map((tp) => {
+                const uniqueMembers = new Set(tp.members.map((m) => m.userId)).size;
+                return (
+                  <Badge key={tp.id} variant="secondary" size="xs" className="gap-1">
+                    {tp.language.name}
+                    {uniqueMembers > 0 && (
+                      <span className="text-muted-foreground">
+                        <Users className="inline h-3 w-3 ml-0.5" /> {uniqueMembers}
+                      </span>
+                    )}
+                  </Badge>
+                );
+              })}
             </div>
           )}
         </CardContent>

--- a/src/components/project-kanban-board.tsx
+++ b/src/components/project-kanban-board.tsx
@@ -20,15 +20,22 @@ import {
   createDocumentAssignmentAction,
   updateDocumentAssignmentAction,
 } from '@/domain/document-assignment/document-assignment.actions';
-import { updateDocumentVersionStatusAction } from '@/domain/document-version/document-version.actions';
+import {
+  assignReviewerToVersionAction,
+  updateDocumentVersionStatusAction,
+} from '@/domain/document-version/document-version.actions';
 import { getDashboardDocumentsAction } from '@/domain/document/document.actions';
 import { listProjectMembersAction } from '@/domain/project-member/project-member.actions';
 import { isAdminClient } from '@/lib/permissions-client';
 import { SessionUser } from '@/lib/session';
+import { toast } from 'sonner';
 import { DocumentStatus, Language } from '@prisma/client';
 import { FileCheck, FileText, Search, UserPlus } from 'lucide-react';
 import Link from 'next/link';
 import { Fragment, useEffect, useMemo, useState } from 'react';
+
+// Radix Select doesn't allow empty string values, so we use a sentinel for "unassign"
+const UNASSIGN_VALUE = '__none__';
 
 type KanbanCardData = {
   id: string;
@@ -136,11 +143,12 @@ export default function ProjectKanbanBoard({
   const [documents, setDocuments] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // Assignment dialog state
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [assignDocId, setAssignDocId] = useState<string | null>(null);
   const [assignExistingId, setAssignExistingId] = useState<string | null>(null);
+  const [assignVersionId, setAssignVersionId] = useState<string | null>(null);
   const [assignUserId, setAssignUserId] = useState('');
+  const [assignReviewerId, setAssignReviewerId] = useState('');
   const [assignDeadline, setAssignDeadline] = useState('');
   const [assignSaving, setAssignSaving] = useState(false);
   const [projectMembers, setProjectMembers] = useState<
@@ -179,35 +187,68 @@ export default function ProjectKanbanBoard({
     }
   }, [translationProjectId, isAdmin]);
 
-  function openAssignDialog(docId: string, existingAssignmentId: string | null) {
-    setAssignDocId(docId);
-    setAssignExistingId(existingAssignmentId);
-    setAssignUserId('');
+  function openAssignDialog(params: {
+    docId: string;
+    existingAssignmentId: string | null;
+    versionId?: string | null;
+    currentTranslatorId?: string | null;
+    currentReviewerId?: string | null;
+  }) {
+    setAssignDocId(params.docId);
+    setAssignExistingId(params.existingAssignmentId);
+    setAssignVersionId(params.versionId ?? null);
+    setAssignUserId(params.currentTranslatorId ?? '');
+    setAssignReviewerId(params.currentReviewerId ?? '');
     setAssignDeadline('');
     setAssignDialogOpen(true);
   }
 
   async function handleAssign() {
-    if (!assignDocId || !assignUserId || !translationProjectId) return;
+    if (!assignDocId || !translationProjectId) return;
     setAssignSaving(true);
     try {
-      if (assignExistingId) {
-        await updateDocumentAssignmentAction(assignExistingId, {
-          userId: assignUserId,
-          deadline: assignDeadline ? new Date(assignDeadline) : null,
-        });
-      } else {
+      const wantsUnassignTranslator = assignUserId === UNASSIGN_VALUE;
+      const wantsUnassignReviewer = assignReviewerId === UNASSIGN_VALUE;
+      const translatorId = !wantsUnassignTranslator && assignUserId ? assignUserId : null;
+      const reviewerId = !wantsUnassignReviewer && assignReviewerId ? assignReviewerId : null;
+
+      if (wantsUnassignTranslator && assignExistingId) {
+        await updateDocumentAssignmentAction(assignExistingId, { userId: null });
+        toast.success('Translator unassigned');
+      } else if (wantsUnassignTranslator && !assignExistingId) {
         await createDocumentAssignmentAction({
           documentId: assignDocId,
           translationProjectId,
-          userId: assignUserId,
-          deadline: assignDeadline ? new Date(assignDeadline) : null,
+          userId: null,
         });
+        toast.success('Translator unassigned');
+      } else if (translatorId) {
+        if (assignExistingId) {
+          await updateDocumentAssignmentAction(assignExistingId, {
+            userId: translatorId,
+            deadline: assignDeadline ? new Date(assignDeadline) : null,
+          });
+        } else {
+          await createDocumentAssignmentAction({
+            documentId: assignDocId,
+            translationProjectId,
+            userId: translatorId,
+            deadline: assignDeadline ? new Date(assignDeadline) : null,
+          });
+        }
+        toast.success('Translator assigned!');
       }
+
+      if (assignVersionId && (wantsUnassignReviewer || reviewerId)) {
+        await assignReviewerToVersionAction(assignVersionId, reviewerId);
+        toast.success(wantsUnassignReviewer ? 'Reviewer unassigned' : 'Reviewer assigned!');
+      }
+
       setAssignDialogOpen(false);
       await loadDocuments();
     } catch (error) {
-      console.error('Error assigning translator:', error);
+      const message = error instanceof Error ? error.message : 'Failed to update assignment';
+      toast.error(message);
     } finally {
       setAssignSaving(false);
     }
@@ -502,9 +543,10 @@ export default function ProjectKanbanBoard({
                                 <div className="flex items-center gap-1.5 shrink-0">
                                   {(() => {
                                     // Show relevant user based on document status
-                                    const translator = version?.user;
+                                    // If assignment exists with userId=null, treat as unassigned
+                                    const translator = assignment ? (assignment.userId ? assignment.user : null) : version?.user;
                                     const reviewer = version?.reviewer;
-                                    const isUnassigned = !assignment?.userId && !translator;
+                                    const isUnassigned = !translator;
 
                                     // For PENDING_REVIEW: show reviewer
                                     // For IN_PROGRESS: show translator
@@ -520,10 +562,7 @@ export default function ProjectKanbanBoard({
                                       if (reviewer && reviewer.id !== translator?.id) usersToShow.push(reviewer);
                                     }
 
-                                    const canReassign =
-                                      isAdmin &&
-                                      translationProjectId &&
-                                      (!version?.status || version?.status === DocumentStatus.PENDING_TRANSLATION);
+                                    const canReassign = isAdmin && translationProjectId;
 
                                     if (isUnassigned && canReassign) {
                                       return (
@@ -531,7 +570,13 @@ export default function ProjectKanbanBoard({
                                           onClick={(e) => {
                                             e.preventDefault();
                                             e.stopPropagation();
-                                            openAssignDialog(doc.id, assignment?.id || null);
+                                            openAssignDialog({
+                                              docId: doc.id,
+                                              existingAssignmentId: assignment?.id || null,
+                                              versionId: version?.id || null,
+                                              currentTranslatorId: assignment?.userId || version?.user?.id || null,
+                                              currentReviewerId: version?.reviewer?.id || null,
+                                            });
                                           }}
                                           className="h-6 w-6 rounded-full border-2 border-dashed border-gray-300 flex items-center justify-center hover:border-gray-400 hover:bg-gray-50 transition-colors"
                                           title="Assign translator"
@@ -549,7 +594,13 @@ export default function ProjectKanbanBoard({
                                           onClick={(e) => {
                                             e.preventDefault();
                                             e.stopPropagation();
-                                            openAssignDialog(doc.id, assignment?.id || null);
+                                            openAssignDialog({
+                                              docId: doc.id,
+                                              existingAssignmentId: assignment?.id || null,
+                                              versionId: version?.id || null,
+                                              currentTranslatorId: assignment?.userId || version?.user?.id || null,
+                                              currentReviewerId: version?.reviewer?.id || null,
+                                            });
                                           }}
                                           className="flex items-center gap-1 -space-x-1 cursor-pointer hover:opacity-70 transition-opacity"
                                           title="Reassign translator"
@@ -630,8 +681,8 @@ export default function ProjectKanbanBoard({
       <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Assign Translator</DialogTitle>
-            <DialogDescription>Select a team member to assign to this document.</DialogDescription>
+            <DialogTitle>Assign Team Members</DialogTitle>
+            <DialogDescription>Select team members to assign to this document.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div className="space-y-2">
@@ -641,6 +692,11 @@ export default function ProjectKanbanBoard({
                   <SelectValue placeholder="Select translator..." />
                 </SelectTrigger>
                 <SelectContent>
+                  {(assignExistingId || assignUserId) && (
+                    <SelectItem value={UNASSIGN_VALUE} className="text-destructive">
+                      Unassign translator
+                    </SelectItem>
+                  )}
                   {projectMembers.map((m) => (
                     <SelectItem key={m.user.id} value={m.user.id}>
                       {m.user.name || m.user.email}
@@ -649,6 +705,26 @@ export default function ProjectKanbanBoard({
                 </SelectContent>
               </Select>
             </div>
+            {assignVersionId && (
+              <div className="space-y-2">
+                <Label>Reviewer</Label>
+                <Select value={assignReviewerId} onValueChange={setAssignReviewerId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select reviewer..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={UNASSIGN_VALUE} className="text-destructive">
+                      Unassign reviewer
+                    </SelectItem>
+                    {projectMembers.map((m) => (
+                      <SelectItem key={m.user.id} value={m.user.id}>
+                        {m.user.name || m.user.email}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <div className="space-y-2">
               <Label>Deadline (optional)</Label>
               <Input type="date" value={assignDeadline} onChange={(e) => setAssignDeadline(e.target.value)} />
@@ -658,8 +734,8 @@ export default function ProjectKanbanBoard({
             <Button variant="outline" onClick={() => setAssignDialogOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={handleAssign} disabled={!assignUserId || assignSaving}>
-              {assignSaving ? 'Assigning...' : 'Assign'}
+            <Button onClick={handleAssign} disabled={(!assignUserId && !assignReviewerId) || assignSaving}>
+              {assignSaving ? 'Saving...' : 'Save'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/domain/document-assignment/document-assignment.actions.ts
+++ b/src/domain/document-assignment/document-assignment.actions.ts
@@ -21,9 +21,6 @@ import {
  * stay consistent.
  */
 async function syncVersionTranslator(documentId: string, translationProjectId: string, userId: string | null) {
-  // Only sync when assigning (not unassigning) — DocumentVersion.userId is required
-  if (!userId) return;
-
   const translationProject = await prisma.translationProject.findUnique({
     where: { id: translationProjectId },
     select: { languageId: true },

--- a/src/domain/github/github.service.ts
+++ b/src/domain/github/github.service.ts
@@ -272,7 +272,7 @@ export async function deployToGitHub(documentVersionId: string): Promise<{ prUrl
     `- **Language**: ${language.name} (${language.code})`,
     `- **File**: \`${filePath}\``,
     `- **Source Project**: ${document.sourceProject.name}`,
-    `- **Translator**: ${version.user.name}`,
+    `- **Translator**: ${version.user?.name ?? 'Unassigned'}`,
     `- **Link to document**: ${process.env.NEXT_PUBLIC_APP_URL}/documents/${document.id}/review?version=${version.id}`,
   ].join('\n');
 

--- a/src/domain/source-project/source-project.repository.ts
+++ b/src/domain/source-project/source-project.repository.ts
@@ -60,9 +60,9 @@ export async function getSourceProjectsForUser(userId: string, isAdmin: boolean)
               code: true,
             },
           },
-          _count: {
+          members: {
             select: {
-              members: true,
+              userId: true,
             },
           },
         },

--- a/src/lib/stores/editor-store.ts
+++ b/src/lib/stores/editor-store.ts
@@ -440,10 +440,18 @@ export function createEditorStore(config: EditorStoreConfig) {
     },
 
     unassignTranslator: async () => {
-      const { assignmentId, targetVersion } = get();
-      if (!assignmentId) return;
+      const { assignmentId, documentId, translationProjectId, targetVersion } = get();
+      if (!assignmentId && !translationProjectId) return;
       try {
-        await updateDocumentAssignmentAction(assignmentId, { userId: null });
+        if (assignmentId) {
+          await updateDocumentAssignmentAction(assignmentId, { userId: null });
+        } else {
+          await createDocumentAssignmentAction({
+            documentId,
+            translationProjectId: translationProjectId!,
+            userId: null,
+          });
+        }
         if (targetVersion) {
           set({ targetVersion: { ...targetVersion, user: null } });
         }


### PR DESCRIPTION
- Updated the DocumentVersion model to allow userId and reviewerId to be optional, enabling more flexible document version management.
- Adjusted the corresponding migration to drop the NOT NULL constraint and update foreign key behavior to SET NULL on delete.
- Enhanced various components to handle potential null values for user and reviewer, ensuring UI consistency and preventing errors.