### PR TITLE
feat: remove register tab + admin invitation management UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/domain/translation/translation.service.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts",
+    "test": "tsx --test src/domain/translation/translation.service.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts",
     "db:seed": "tsx prisma/seed.ts",
     "format": "prettier --write ."
   },

--- a/src/app/admin/users/page.client.tsx
+++ b/src/app/admin/users/page.client.tsx
@@ -15,13 +15,25 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { updateUserRoleAction } from '@/domain/user/user.actions';
+import {
+  createInvitationAction,
+  revokeInvitationAction,
+} from '@/domain/invitation/invitation.actions';
 import { authClient } from '@/lib/auth-client';
-import { Role } from '@prisma/client';
-import { Ban, Shield, Unlock } from 'lucide-react';
+import { Role, InvitationStatus } from '@prisma/client';
+import {
+  getInvitationDisplayStatus,
+  type InvitationDisplayStatus,
+} from '@/domain/invitation/invitation.display-status';
+import { Ban, Check, Clock, Copy, Link2, Plus, Shield, Unlock, X } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
+
+// ─── Types ──────────────────────────────────────────────────
 
 interface User {
   id: string;
@@ -36,16 +48,59 @@ interface User {
   updatedAt: Date;
 }
 
-interface UsersClientProps {
-  users: User[];
+interface Invitation {
+  id: string;
+  token: string;
+  maxUses: number | null;
+  usedCount: number;
+  expiresAt: Date;
+  status: InvitationStatus;
+  createdAt: Date;
+  createdBy: { id: string; name: string; email: string };
 }
 
-export default function UsersClient({ users: initialUsers }: UsersClientProps) {
+interface UsersClientProps {
+  users: User[];
+  invitations: Invitation[];
+}
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function statusBadge(status: InvitationDisplayStatus) {
+  switch (status) {
+    case 'active':
+      return <Badge variant="success"><Clock className="h-3 w-3 mr-1" />Active</Badge>;
+    case 'revoked':
+      return <Badge variant="destructive"><X className="h-3 w-3 mr-1" />Revoked</Badge>;
+    case 'expired':
+      return <Badge variant="secondary"><Clock className="h-3 w-3 mr-1" />Expired</Badge>;
+    case 'exhausted':
+      return <Badge variant="secondary"><Check className="h-3 w-3 mr-1" />Fully Used</Badge>;
+  }
+}
+
+function truncateToken(token: string) {
+  return token.length > 12 ? `${token.slice(0, 8)}...${token.slice(-4)}` : token;
+}
+
+// ─── Component ──────────────────────────────────────────────
+
+export default function UsersClient({ users: initialUsers, invitations: initialInvitations }: UsersClientProps) {
+  // Users state
   const [users, setUsers] = useState(initialUsers);
   const [roleDialogOpen, setRoleDialogOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [selectedRole, setSelectedRole] = useState<Role | ''>('');
   const [loading, setLoading] = useState(false);
+
+  // Invitations state
+  const [invitations, setInvitations] = useState(initialInvitations);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [maxUses, setMaxUses] = useState('');
+  const [expiresInDays, setExpiresInDays] = useState('30');
+  const [createdInviteUrl, setCreatedInviteUrl] = useState<string | null>(null);
+
+  // ─── User actions ───────────────────────────────────────
 
   const handleRoleChange = async (userId: string, newRole: Role) => {
     setLoading(true);
@@ -64,14 +119,8 @@ export default function UsersClient({ users: initialUsers }: UsersClientProps) {
   const handleBanUser = async (userId: string) => {
     setLoading(true);
     try {
-      const result = await authClient.admin.banUser({
-        userId,
-      });
-
-      if (result.error) {
-        throw new Error(result.error.message);
-      }
-
+      const result = await authClient.admin.banUser({ userId });
+      if (result.error) throw new Error(result.error.message);
       setUsers(
         users.map((u) =>
           u.id === userId
@@ -93,21 +142,11 @@ export default function UsersClient({ users: initialUsers }: UsersClientProps) {
     }
   };
 
-  const handleBanUserConfirm = async (userId: string) => {
-    await handleBanUser(userId);
-  };
-
   const handleUnbanUser = async (userId: string) => {
     setLoading(true);
     try {
-      const result = await authClient.admin.unbanUser({
-        userId,
-      });
-
-      if (result.error) {
-        throw new Error(result.error.message);
-      }
-
+      const result = await authClient.admin.unbanUser({ userId });
+      if (result.error) throw new Error(result.error.message);
       setUsers(users.map((u) => (u.id === userId ? { ...u, banned: false, banReason: null, banExpires: null } : u)));
       toast.success('User unbanned successfully');
     } catch (error: any) {
@@ -116,10 +155,6 @@ export default function UsersClient({ users: initialUsers }: UsersClientProps) {
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleUnbanUserConfirm = async (userId: string) => {
-    await handleUnbanUser(userId);
   };
 
   const openRoleDialog = (user: User) => {
@@ -131,7 +166,6 @@ export default function UsersClient({ users: initialUsers }: UsersClientProps) {
   const handleRoleDialogSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editingUser || !selectedRole) return;
-
     setLoading(true);
     try {
       await handleRoleChange(editingUser.id, selectedRole);
@@ -146,101 +180,250 @@ export default function UsersClient({ users: initialUsers }: UsersClientProps) {
     }
   };
 
+  // ─── Invitation actions ─────────────────────────────────
+
+  const handleCreateInvitation = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const expiresAt = expiresInDays
+        ? new Date(Date.now() + Number(expiresInDays) * 24 * 60 * 60 * 1000)
+        : undefined;
+      const result = await createInvitationAction({
+        maxUses: maxUses ? Number(maxUses) : null,
+        expiresAt,
+      });
+      setCreatedInviteUrl(result.inviteUrl);
+      setInvitations([
+        {
+          ...result,
+          usedCount: 0,
+          status: 'ACTIVE' as InvitationStatus,
+          createdBy: { id: '', name: 'You', email: '' },
+        },
+        ...invitations,
+      ]);
+      toast.success('Invitation created');
+    } catch (error: any) {
+      console.error('Error creating invitation:', error);
+      toast.error(error.message || 'Failed to create invitation');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopyUrl = async (url: string) => {
+    await navigator.clipboard.writeText(url);
+    toast.success('Invite link copied to clipboard');
+  };
+
+  const handleRevoke = async (id: string) => {
+    setLoading(true);
+    try {
+      await revokeInvitationAction(id);
+      setInvitations(invitations.map((inv) => (inv.id === id ? { ...inv, status: 'REVOKED' as InvitationStatus } : inv)));
+      toast.success('Invitation revoked');
+    } catch (error: any) {
+      console.error('Error revoking invitation:', error);
+      toast.error(error.message || 'Failed to revoke invitation');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetCreateDialog = () => {
+    setCreateDialogOpen(false);
+    setMaxUses('');
+    setExpiresInDays('30');
+    setCreatedInviteUrl(null);
+  };
+
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+
+  // ─── Render ─────────────────────────────────────────────
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="border-b bg-white">
         <div className="container mx-auto px-4 py-4">
           <div>
             <h1 className="text-2xl font-bold">User Management</h1>
-            <p className="text-gray-600">Manage users, roles, and bans</p>
+            <p className="text-gray-600">Manage users, roles, bans, and invitations</p>
           </div>
         </div>
       </div>
 
-      <div className="container mx-auto px-4 py-4">
-        <div className="grid gap-4">
-          {users.map((user) => (
-            <Card key={user.id} className="p-4">
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-3">
-                    <h3 className="font-semibold text-lg">{user.name}</h3>
-                    <Badge variant={user.role === Role.ADMIN ? 'primary' : 'secondary'}>
-                      {user.role === Role.ADMIN ? <Shield className="h-3 w-3 mr-1" /> : null}
-                      {user.role}
-                    </Badge>
-                    {user.banned && (
-                      <Badge variant="destructive">
-                        <Ban className="h-3 w-3 mr-1" />
-                        Banned
+      <div className="container mx-auto px-4 py-4 space-y-8">
+        {/* ── Invitations Section ────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Invitations</h2>
+            <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Create Invitation
+            </Button>
+          </div>
+
+          {invitations.length === 0 ? (
+            <Card className="p-6 text-center text-gray-500">
+              No invitations yet. Create one to invite translators.
+            </Card>
+          ) : (
+            <div className="grid gap-3">
+              {invitations.map((inv) => {
+                const displayStatus = getInvitationDisplayStatus(inv);
+                return (
+                  <Card key={inv.id} className="p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-3">
+                          <code className="text-sm bg-gray-100 px-2 py-0.5 rounded font-mono">
+                            {truncateToken(inv.token)}
+                          </code>
+                          {statusBadge(displayStatus)}
+                        </div>
+                        <div className="flex gap-4 mt-2 text-sm text-gray-600">
+                          <span>
+                            Uses: {inv.usedCount}/{inv.maxUses ?? '∞'}
+                          </span>
+                          <span>
+                            Expires: {new Date(inv.expiresAt).toLocaleDateString()}
+                          </span>
+                          <span>
+                            By: {inv.createdBy.name}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex gap-2 ml-4">
+                        {displayStatus === 'active' && (
+                          <>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleCopyUrl(`${baseUrl}/register/${inv.token}`)}
+                            >
+                              <Copy className="h-4 w-4 mr-1" />
+                              Copy Link
+                            </Button>
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <Button variant="outline" size="sm" disabled={loading}>
+                                  <X className="h-4 w-4 mr-1" />
+                                  Revoke
+                                </Button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>Revoke Invitation</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    This will permanently invalidate this invitation link. Anyone with the link will no longer be able to register.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                  <AlertDialogAction onClick={() => handleRevoke(inv.id)}>Revoke</AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        {/* ── Users Section ──────────────────────────────── */}
+        <section>
+          <h2 className="text-lg font-semibold mb-4">Users</h2>
+          <div className="grid gap-4">
+            {users.map((user) => (
+              <Card key={user.id} className="p-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3">
+                      <h3 className="font-semibold text-lg">{user.name}</h3>
+                      <Badge variant={user.role === Role.ADMIN ? 'primary' : 'secondary'}>
+                        {user.role === Role.ADMIN ? <Shield className="h-3 w-3 mr-1" /> : null}
+                        {user.role}
                       </Badge>
+                      {user.banned && (
+                        <Badge variant="destructive">
+                          <Ban className="h-3 w-3 mr-1" />
+                          Banned
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-600 mt-1">{user.email}</p>
+                    {user.banned && user.banReason && (
+                      <p className="text-sm text-red-600 mt-1">Reason: {user.banReason}</p>
+                    )}
+                    {user.banned && user.banExpires && (
+                      <p className="text-sm text-gray-500 mt-1">
+                        Expires: {new Date(user.banExpires).toLocaleDateString()}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-400 mt-1">Joined: {new Date(user.createdAt).toLocaleDateString()}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={() => openRoleDialog(user)} disabled={loading}>
+                      Change Role
+                    </Button>
+                    {user.banned ? (
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button variant="outline" size="sm" disabled={loading}>
+                            <Unlock className="h-4 w-4 mr-2" />
+                            Unban
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Unban User</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              Are you sure you want to unban {user.name}? They will be able to access the system again.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => handleUnbanUser(user.id)}>Unban</AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    ) : (
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button variant="outline" size="sm" disabled={loading}>
+                            <Ban className="h-4 w-4 mr-2" />
+                            Ban
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Ban User</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              Are you sure you want to ban {user.name}? This will prevent them from accessing the system.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => handleBanUser(user.id)}>Ban</AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
                     )}
                   </div>
-                  <p className="text-sm text-gray-600 mt-1">{user.email}</p>
-                  {user.banned && user.banReason && (
-                    <p className="text-sm text-red-600 mt-1">Reason: {user.banReason}</p>
-                  )}
-                  {user.banned && user.banExpires && (
-                    <p className="text-sm text-gray-500 mt-1">
-                      Expires: {new Date(user.banExpires).toLocaleDateString()}
-                    </p>
-                  )}
-                  <p className="text-xs text-gray-400 mt-1">Joined: {new Date(user.createdAt).toLocaleDateString()}</p>
                 </div>
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm" onClick={() => openRoleDialog(user)} disabled={loading}>
-                    Change Role
-                  </Button>
-                  {user.banned ? (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button variant="outline" size="sm" disabled={loading}>
-                          <Unlock className="h-4 w-4 mr-2" />
-                          Unban
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Unban User</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Are you sure you want to unban {user.name}? They will be able to access the system again.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction onClick={() => handleUnbanUserConfirm(user.id)}>Unban</AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  ) : (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button variant="outline" size="sm" disabled={loading}>
-                          <Ban className="h-4 w-4 mr-2" />
-                          Ban
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Ban User</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Are you sure you want to ban {user.name}? This will prevent them from accessing the system.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction onClick={() => handleBanUserConfirm(user.id)}>Ban</AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  )}
-                </div>
-              </div>
-            </Card>
-          ))}
-        </div>
+              </Card>
+            ))}
+          </div>
+        </section>
       </div>
 
+      {/* ── Role Change Dialog ────────────────────────────── */}
       <Dialog
         open={roleDialogOpen}
         onOpenChange={(open) => {
@@ -277,6 +460,78 @@ export default function UsersClient({ users: initialUsers }: UsersClientProps) {
               </Button>
             </div>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Create Invitation Dialog ──────────────────────── */}
+      <Dialog open={createDialogOpen} onOpenChange={(open) => { if (!open) resetCreateDialog(); else setCreateDialogOpen(true); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {createdInviteUrl ? 'Invitation Created' : 'Create Invitation'}
+            </DialogTitle>
+          </DialogHeader>
+
+          {createdInviteUrl ? (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                Share this link with the person you want to invite:
+              </p>
+              <div className="flex items-center gap-2">
+                <Input value={createdInviteUrl} readOnly className="font-mono text-sm" />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopyUrl(createdInviteUrl)}
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="flex justify-end">
+                <Button type="button" onClick={resetCreateDialog}>
+                  Done
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleCreateInvitation} className="space-y-4">
+              <div>
+                <Label htmlFor="max-uses">Max Uses</Label>
+                <Input
+                  id="max-uses"
+                  type="number"
+                  min="1"
+                  value={maxUses}
+                  onChange={(e) => setMaxUses(e.target.value)}
+                  placeholder="Leave empty for unlimited"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  How many people can register with this link. Empty = unlimited.
+                </p>
+              </div>
+              <div>
+                <Label htmlFor="expires-in">Expires In (days)</Label>
+                <Input
+                  id="expires-in"
+                  type="number"
+                  min="1"
+                  value={expiresInDays}
+                  onChange={(e) => setExpiresInDays(e.target.value)}
+                  placeholder="30"
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" onClick={resetCreateDialog}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={loading}>
+                  <Link2 className="h-4 w-4 mr-2" />
+                  {loading ? 'Creating...' : 'Create'}
+                </Button>
+              </div>
+            </form>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/app/admin/users/page.client.tsx
+++ b/src/app/admin/users/page.client.tsx
@@ -18,19 +18,20 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { updateUserRoleAction } from '@/domain/user/user.actions';
 import {
   createInvitationAction,
   revokeInvitationAction,
 } from '@/domain/invitation/invitation.actions';
-import { authClient } from '@/lib/auth-client';
-import { Role, InvitationStatus } from '@prisma/client';
 import {
   getInvitationDisplayStatus,
   type InvitationDisplayStatus,
 } from '@/domain/invitation/invitation.display-status';
-import { Ban, Check, Clock, Copy, Link2, Plus, Shield, Unlock, X } from 'lucide-react';
-import { useState } from 'react';
+import { authClient } from '@/lib/auth-client';
+import { Role, InvitationStatus } from '@prisma/client';
+import { Ban, Check, ChevronLeft, ChevronRight, Clock, Copy, Link2, Plus, Shield, Unlock, Users, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 // ─── Types ──────────────────────────────────────────────────
@@ -66,7 +67,7 @@ interface UsersClientProps {
 
 // ─── Helpers ────────────────────────────────────────────────
 
-function statusBadge(status: InvitationDisplayStatus) {
+function invitationStatusBadge(status: InvitationDisplayStatus) {
   switch (status) {
     case 'active':
       return <Badge variant="success"><Clock className="h-3 w-3 mr-1" />Active</Badge>;
@@ -82,6 +83,10 @@ function statusBadge(status: InvitationDisplayStatus) {
 function truncateToken(token: string) {
   return token.length > 12 ? `${token.slice(0, 8)}...${token.slice(-4)}` : token;
 }
+
+const INVITATIONS_PER_PAGE = 10;
+
+type InvitationFilter = 'active' | 'inactive';
 
 // ─── Component ──────────────────────────────────────────────
 
@@ -99,6 +104,29 @@ export default function UsersClient({ users: initialUsers, invitations: initialI
   const [maxUses, setMaxUses] = useState('');
   const [expiresInDays, setExpiresInDays] = useState('30');
   const [createdInviteUrl, setCreatedInviteUrl] = useState<string | null>(null);
+  const [invitationFilter, setInvitationFilter] = useState<InvitationFilter>('active');
+  const [invitationPage, setInvitationPage] = useState(1);
+
+  // ─── Filtered & paginated invitations ───────────────────
+
+  const filteredInvitations = useMemo(() => {
+    return invitations.filter((inv) => {
+      const status = getInvitationDisplayStatus(inv);
+      return invitationFilter === 'active' ? status === 'active' : status !== 'active';
+    });
+  }, [invitations, invitationFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredInvitations.length / INVITATIONS_PER_PAGE));
+  const clampedPage = Math.min(invitationPage, totalPages);
+  const paginatedInvitations = filteredInvitations.slice(
+    (clampedPage - 1) * INVITATIONS_PER_PAGE,
+    clampedPage * INVITATIONS_PER_PAGE,
+  );
+
+  const handleFilterChange = (filter: InvitationFilter) => {
+    setInvitationFilter(filter);
+    setInvitationPage(1);
+  };
 
   // ─── User actions ───────────────────────────────────────
 
@@ -246,181 +274,234 @@ export default function UsersClient({ users: initialUsers, invitations: initialI
     <div className="min-h-screen bg-gray-50">
       <div className="border-b bg-white">
         <div className="container mx-auto px-4 py-4">
-          <div>
-            <h1 className="text-2xl font-bold">User Management</h1>
-            <p className="text-gray-600">Manage users, roles, bans, and invitations</p>
-          </div>
+          <h1 className="text-2xl font-bold">User Management</h1>
+          <p className="text-gray-600">Manage users, roles, bans, and invitations</p>
         </div>
       </div>
 
-      <div className="container mx-auto px-4 py-4 space-y-8">
-        {/* ── Invitations Section ────────────────────────── */}
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold">Invitations</h2>
-            <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Create Invitation
-            </Button>
-          </div>
+      <div className="container mx-auto px-4 py-4">
+        <Tabs defaultValue="users">
+          <TabsList>
+            <TabsTrigger value="users">Users</TabsTrigger>
+            <TabsTrigger value="invitations">Invitations</TabsTrigger>
+          </TabsList>
 
-          {invitations.length === 0 ? (
-            <Card className="p-6 text-center text-gray-500">
-              No invitations yet. Create one to invite translators.
-            </Card>
-          ) : (
-            <div className="grid gap-3">
-              {invitations.map((inv) => {
-                const displayStatus = getInvitationDisplayStatus(inv);
-                return (
-                  <Card key={inv.id} className="p-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-3">
-                          <code className="text-sm bg-gray-100 px-2 py-0.5 rounded font-mono">
-                            {truncateToken(inv.token)}
-                          </code>
-                          {statusBadge(displayStatus)}
-                        </div>
-                        <div className="flex gap-4 mt-2 text-sm text-gray-600">
-                          <span>
-                            Uses: {inv.usedCount}/{inv.maxUses ?? '∞'}
-                          </span>
-                          <span>
-                            Expires: {new Date(inv.expiresAt).toLocaleDateString()}
-                          </span>
-                          <span>
-                            By: {inv.createdBy.name}
-                          </span>
-                        </div>
-                      </div>
-                      <div className="flex gap-2 ml-4">
-                        {displayStatus === 'active' && (
-                          <>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => handleCopyUrl(`${baseUrl}/register/${inv.token}`)}
-                            >
-                              <Copy className="h-4 w-4 mr-1" />
-                              Copy Link
-                            </Button>
-                            <AlertDialog>
-                              <AlertDialogTrigger asChild>
-                                <Button variant="outline" size="sm" disabled={loading}>
-                                  <X className="h-4 w-4 mr-1" />
-                                  Revoke
-                                </Button>
-                              </AlertDialogTrigger>
-                              <AlertDialogContent>
-                                <AlertDialogHeader>
-                                  <AlertDialogTitle>Revoke Invitation</AlertDialogTitle>
-                                  <AlertDialogDescription>
-                                    This will permanently invalidate this invitation link. Anyone with the link will no longer be able to register.
-                                  </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                  <AlertDialogAction onClick={() => handleRevoke(inv.id)}>Revoke</AlertDialogAction>
-                                </AlertDialogFooter>
-                              </AlertDialogContent>
-                            </AlertDialog>
-                          </>
+          {/* ── Users Tab ──────────────────────────────────── */}
+          <TabsContent value="users">
+            <div className="grid gap-4">
+              {users.map((user) => (
+                <Card key={user.id} className="p-4">
+                  <div className="flex items-center justify-between">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3">
+                        <h3 className="font-semibold text-lg">{user.name}</h3>
+                        <Badge variant={user.role === Role.ADMIN ? 'primary' : 'secondary'}>
+                          {user.role === Role.ADMIN ? <Shield className="h-3 w-3 mr-1" /> : null}
+                          {user.role}
+                        </Badge>
+                        {user.banned && (
+                          <Badge variant="destructive">
+                            <Ban className="h-3 w-3 mr-1" />
+                            Banned
+                          </Badge>
                         )}
                       </div>
+                      <p className="text-sm text-gray-600 mt-1">{user.email}</p>
+                      {user.banned && user.banReason && (
+                        <p className="text-sm text-red-600 mt-1">Reason: {user.banReason}</p>
+                      )}
+                      {user.banned && user.banExpires && (
+                        <p className="text-sm text-gray-500 mt-1">
+                          Expires: {new Date(user.banExpires).toLocaleDateString()}
+                        </p>
+                      )}
+                      <p className="text-xs text-gray-400 mt-1">Joined: {new Date(user.createdAt).toLocaleDateString()}</p>
                     </div>
-                  </Card>
-                );
-              })}
-            </div>
-          )}
-        </section>
-
-        {/* ── Users Section ──────────────────────────────── */}
-        <section>
-          <h2 className="text-lg font-semibold mb-4">Users</h2>
-          <div className="grid gap-4">
-            {users.map((user) => (
-              <Card key={user.id} className="p-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3">
-                      <h3 className="font-semibold text-lg">{user.name}</h3>
-                      <Badge variant={user.role === Role.ADMIN ? 'primary' : 'secondary'}>
-                        {user.role === Role.ADMIN ? <Shield className="h-3 w-3 mr-1" /> : null}
-                        {user.role}
-                      </Badge>
-                      {user.banned && (
-                        <Badge variant="destructive">
-                          <Ban className="h-3 w-3 mr-1" />
-                          Banned
-                        </Badge>
+                    <div className="flex gap-2">
+                      <Button variant="outline" size="sm" onClick={() => openRoleDialog(user)} disabled={loading}>
+                        Change Role
+                      </Button>
+                      {user.banned ? (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button variant="outline" size="sm" disabled={loading}>
+                              <Unlock className="h-4 w-4 mr-2" />
+                              Unban
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Unban User</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Are you sure you want to unban {user.name}? They will be able to access the system again.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction onClick={() => handleUnbanUser(user.id)}>Unban</AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      ) : (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button variant="outline" size="sm" disabled={loading}>
+                              <Ban className="h-4 w-4 mr-2" />
+                              Ban
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Ban User</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Are you sure you want to ban {user.name}? This will prevent them from accessing the system.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction onClick={() => handleBanUser(user.id)}>Ban</AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       )}
                     </div>
-                    <p className="text-sm text-gray-600 mt-1">{user.email}</p>
-                    {user.banned && user.banReason && (
-                      <p className="text-sm text-red-600 mt-1">Reason: {user.banReason}</p>
-                    )}
-                    {user.banned && user.banExpires && (
-                      <p className="text-sm text-gray-500 mt-1">
-                        Expires: {new Date(user.banExpires).toLocaleDateString()}
-                      </p>
-                    )}
-                    <p className="text-xs text-gray-400 mt-1">Joined: {new Date(user.createdAt).toLocaleDateString()}</p>
                   </div>
-                  <div className="flex gap-2">
-                    <Button variant="outline" size="sm" onClick={() => openRoleDialog(user)} disabled={loading}>
-                      Change Role
-                    </Button>
-                    {user.banned ? (
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button variant="outline" size="sm" disabled={loading}>
-                            <Unlock className="h-4 w-4 mr-2" />
-                            Unban
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Unban User</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              Are you sure you want to unban {user.name}? They will be able to access the system again.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => handleUnbanUser(user.id)}>Unban</AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    ) : (
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button variant="outline" size="sm" disabled={loading}>
-                            <Ban className="h-4 w-4 mr-2" />
-                            Ban
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>Ban User</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              Are you sure you want to ban {user.name}? This will prevent them from accessing the system.
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={() => handleBanUser(user.id)}>Ban</AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    )}
-                  </div>
-                </div>
+                </Card>
+              ))}
+            </div>
+          </TabsContent>
+
+          {/* ── Invitations Tab ────────────────────────────── */}
+          <TabsContent value="invitations">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <Button
+                  variant={invitationFilter === 'active' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => handleFilterChange('active')}
+                >
+                  Active
+                </Button>
+                <Button
+                  variant={invitationFilter === 'inactive' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => handleFilterChange('inactive')}
+                >
+                  Inactive
+                </Button>
+              </div>
+              <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Create Invitation
+              </Button>
+            </div>
+
+            {filteredInvitations.length === 0 ? (
+              <Card className="p-6 text-center text-gray-500">
+                {invitationFilter === 'active'
+                  ? 'No active invitations. Create one to invite translators.'
+                  : 'No inactive invitations.'}
               </Card>
-            ))}
-          </div>
-        </section>
+            ) : (
+              <>
+                <div className="grid gap-3">
+                  {paginatedInvitations.map((inv) => {
+                    const displayStatus = getInvitationDisplayStatus(inv);
+                    return (
+                      <Card key={inv.id} className="p-4">
+                        <div className="flex items-center justify-between">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-3">
+                              <code className="text-sm bg-gray-100 px-2 py-0.5 rounded font-mono">
+                                {truncateToken(inv.token)}
+                              </code>
+                              {invitationStatusBadge(displayStatus)}
+                            </div>
+                            <div className="flex gap-4 mt-2 text-sm text-gray-600">
+                              <span>
+                                Uses: {inv.usedCount}/{inv.maxUses ?? '\u221e'}
+                              </span>
+                              <span>
+                                Expires: {new Date(inv.expiresAt).toLocaleDateString()}
+                              </span>
+                              <span>
+                                By: {inv.createdBy.name}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="flex gap-2 ml-4">
+                            {displayStatus === 'active' && (
+                              <>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => handleCopyUrl(`${baseUrl}/register/${inv.token}`)}
+                                >
+                                  <Copy className="h-4 w-4 mr-1" />
+                                  Copy Link
+                                </Button>
+                                <AlertDialog>
+                                  <AlertDialogTrigger asChild>
+                                    <Button variant="outline" size="sm" disabled={loading}>
+                                      <X className="h-4 w-4 mr-1" />
+                                      Revoke
+                                    </Button>
+                                  </AlertDialogTrigger>
+                                  <AlertDialogContent>
+                                    <AlertDialogHeader>
+                                      <AlertDialogTitle>Revoke Invitation</AlertDialogTitle>
+                                      <AlertDialogDescription>
+                                        This will permanently invalidate this invitation link. Anyone with the link will no longer be able to register.
+                                      </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                      <AlertDialogAction onClick={() => handleRevoke(inv.id)}>Revoke</AlertDialogAction>
+                                    </AlertDialogFooter>
+                                  </AlertDialogContent>
+                                </AlertDialog>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                      </Card>
+                    );
+                  })}
+                </div>
+
+                {/* Pagination */}
+                {totalPages > 1 && (
+                  <div className="flex items-center justify-between mt-4">
+                    <p className="text-sm text-gray-500">
+                      {filteredInvitations.length} invitation{filteredInvitations.length !== 1 ? 's' : ''}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={clampedPage <= 1}
+                        onClick={() => setInvitationPage(clampedPage - 1)}
+                      >
+                        <ChevronLeft className="h-4 w-4" />
+                      </Button>
+                      <span className="text-sm text-gray-600">
+                        {clampedPage} / {totalPages}
+                      </span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={clampedPage >= totalPages}
+                        onClick={() => setInvitationPage(clampedPage + 1)}
+                      >
+                        <ChevronRight className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </TabsContent>
+        </Tabs>
       </div>
 
       {/* ── Role Change Dialog ────────────────────────────── */}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@/lib/session';
 import { listUsersAction } from '@/domain/user/user.actions';
+import { listInvitationsAction } from '@/domain/invitation/invitation.actions';
 import UsersClient from './page.client';
 
 export default async function UsersPage() {
@@ -14,7 +15,10 @@ export default async function UsersPage() {
     redirect('/dashboard');
   }
 
-  const users = await listUsersAction();
+  const [users, invitations] = await Promise.all([
+    listUsersAction(),
+    listInvitationsAction(),
+  ]);
 
-  return <UsersClient users={users} />;
+  return <UsersClient users={users} invitations={invitations} />;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,8 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { signIn, signUp } from '@/lib/auth-client';
+import { signIn } from '@/lib/auth-client';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -13,11 +12,8 @@ import { toast } from 'sonner';
 export default function LoginPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [loginEmail, setLoginEmail] = useState('');
-  const [loginPassword, setLoginPassword] = useState('');
-  const [registerEmail, setRegisterEmail] = useState('');
-  const [registerPassword, setRegisterPassword] = useState('');
-  const [registerName, setRegisterName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -25,10 +21,9 @@ export default function LoginPage() {
 
     try {
       const result = await signIn.email({
-        email: loginEmail,
-        password: loginPassword,
+        email,
+        password,
       });
-      console.log(JSON.stringify(result.data, null, 2));
       if (result.data) {
         router.push('/dashboard');
       } else {
@@ -42,28 +37,6 @@ export default function LoginPage() {
     }
   };
 
-  const handleRegister = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-
-    try {
-      const result = await signUp.email({
-        email: registerEmail,
-        password: registerPassword,
-        name: registerName,
-      });
-      console.log(JSON.stringify(result.data, null, 2));
-      if (result.data) {
-        router.push('/onboarding/languages');
-      } else {
-        toast.error(result.error.message || 'Failed to register');
-      }
-    } catch (error: any) {
-      console.error('Register error:', error);
-      toast.error(error.message || 'Failed to register');
-    }
-  };
-
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
       <Card className="w-full max-w-md p-4">
@@ -72,83 +45,33 @@ export default function LoginPage() {
           <p className="text-gray-600">Manage your translations efficiently</p>
         </div>
 
-        <Tabs defaultValue="login">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="login">Login</TabsTrigger>
-            <TabsTrigger value="register">Register</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="login">
-            <form onSubmit={handleLogin} className="space-y-4">
-              <div>
-                <Label htmlFor="login-email">Email</Label>
-                <Input
-                  id="login-email"
-                  type="email"
-                  value={loginEmail}
-                  onChange={(e) => setLoginEmail(e.target.value)}
-                  required
-                  placeholder="your@email.com"
-                />
-              </div>
-              <div>
-                <Label htmlFor="login-password">Password</Label>
-                <Input
-                  id="login-password"
-                  type="password"
-                  value={loginPassword}
-                  onChange={(e) => setLoginPassword(e.target.value)}
-                  required
-                  placeholder="••••••••"
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Logging in...' : 'Login'}
-              </Button>
-            </form>
-          </TabsContent>
-
-          <TabsContent value="register">
-            <form onSubmit={handleRegister} className="space-y-4">
-              <div>
-                <Label htmlFor="register-name">Name</Label>
-                <Input
-                  id="register-name"
-                  value={registerName}
-                  onChange={(e) => setRegisterName(e.target.value)}
-                  required
-                  placeholder="Your name"
-                />
-              </div>
-              <div>
-                <Label htmlFor="register-email">Email</Label>
-                <Input
-                  id="register-email"
-                  type="email"
-                  value={registerEmail}
-                  onChange={(e) => setRegisterEmail(e.target.value)}
-                  required
-                  placeholder="your@email.com"
-                />
-              </div>
-              <div>
-                <Label htmlFor="register-password">Password</Label>
-                <Input
-                  id="register-password"
-                  type="password"
-                  value={registerPassword}
-                  onChange={(e) => setRegisterPassword(e.target.value)}
-                  required
-                  placeholder="••••••••"
-                  minLength={8}
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Creating account...' : 'Create Account'}
-              </Button>
-            </form>
-          </TabsContent>
-        </Tabs>
+        <form onSubmit={handleLogin} className="space-y-4">
+          <div>
+            <Label htmlFor="login-email">Email</Label>
+            <Input
+              id="login-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder="your@email.com"
+            />
+          </div>
+          <div>
+            <Label htmlFor="login-password">Password</Label>
+            <Input
+              id="login-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              placeholder="••••••••"
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Logging in...' : 'Login'}
+          </Button>
+        </form>
       </Card>
     </div>
   );

--- a/src/domain/invitation/invitation.display-status.test.ts
+++ b/src/domain/invitation/invitation.display-status.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getInvitationDisplayStatus, type InvitationForDisplayStatus } from './invitation.display-status';
+
+function createInvitation(overrides: Partial<InvitationForDisplayStatus> = {}): InvitationForDisplayStatus {
+  return {
+    status: 'ACTIVE',
+    expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    usedCount: 0,
+    maxUses: null,
+    ...overrides,
+  };
+}
+
+describe('getInvitationDisplayStatus', () => {
+  it('returns active for a fresh unlimited invitation', () => {
+    assert.equal(getInvitationDisplayStatus(createInvitation()), 'active');
+  });
+
+  it('returns active for a partially used multi-use invitation', () => {
+    assert.equal(getInvitationDisplayStatus(createInvitation({ maxUses: 5, usedCount: 2 })), 'active');
+  });
+
+  it('returns revoked when status is REVOKED', () => {
+    assert.equal(getInvitationDisplayStatus(createInvitation({ status: 'REVOKED' })), 'revoked');
+  });
+
+  it('returns expired when expiresAt is in the past', () => {
+    assert.equal(
+      getInvitationDisplayStatus(createInvitation({ expiresAt: new Date(Date.now() - 1000) })),
+      'expired',
+    );
+  });
+
+  it('returns exhausted when usedCount reaches maxUses', () => {
+    assert.equal(
+      getInvitationDisplayStatus(createInvitation({ maxUses: 3, usedCount: 3 })),
+      'exhausted',
+    );
+  });
+
+  it('returns exhausted when usedCount exceeds maxUses', () => {
+    assert.equal(
+      getInvitationDisplayStatus(createInvitation({ maxUses: 1, usedCount: 5 })),
+      'exhausted',
+    );
+  });
+
+  it('never returns exhausted for unlimited invitations regardless of usedCount', () => {
+    assert.equal(
+      getInvitationDisplayStatus(createInvitation({ maxUses: null, usedCount: 9999 })),
+      'active',
+    );
+  });
+
+  // Priority: revoked > expired > exhausted
+  it('revoked takes priority over expired', () => {
+    assert.equal(
+      getInvitationDisplayStatus(createInvitation({
+        status: 'REVOKED',
+        expiresAt: new Date(Date.now() - 1000),
+      })),
+      'revoked',
+    );
+  });
+
+  it('expired takes priority over exhausted', () => {
+    assert.equal(
+      getInvitationDisplayStatus(createInvitation({
+        expiresAt: new Date(Date.now() - 1000),
+        maxUses: 1,
+        usedCount: 1,
+      })),
+      'expired',
+    );
+  });
+});

--- a/src/domain/invitation/invitation.display-status.ts
+++ b/src/domain/invitation/invitation.display-status.ts
@@ -1,0 +1,17 @@
+import type { InvitationStatus } from '@prisma/client';
+
+export type InvitationDisplayStatus = 'active' | 'revoked' | 'expired' | 'exhausted';
+
+export interface InvitationForDisplayStatus {
+  status: InvitationStatus;
+  expiresAt: Date;
+  usedCount: number;
+  maxUses: number | null;
+}
+
+export function getInvitationDisplayStatus(inv: InvitationForDisplayStatus): InvitationDisplayStatus {
+  if (inv.status === 'REVOKED') return 'revoked';
+  if (new Date(inv.expiresAt) < new Date()) return 'expired';
+  if (inv.maxUses !== null && inv.usedCount >= inv.maxUses) return 'exhausted';
+  return 'active';
+}

--- a/src/domain/invitation/invitation.types.test.ts
+++ b/src/domain/invitation/invitation.types.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createInvitationSchema, registerWithInviteSchema } from './invitation.types';
+
+// ─── createInvitationSchema ─────────────────────────────────
+
+describe('createInvitationSchema', () => {
+  it('accepts empty object (all defaults)', () => {
+    const result = createInvitationSchema.parse({});
+    assert.equal(result.maxUses, null);
+    assert.equal(result.expiresAt, undefined);
+  });
+
+  it('accepts explicit maxUses', () => {
+    const result = createInvitationSchema.parse({ maxUses: 5 });
+    assert.equal(result.maxUses, 5);
+  });
+
+  it('accepts null maxUses (unlimited)', () => {
+    const result = createInvitationSchema.parse({ maxUses: null });
+    assert.equal(result.maxUses, null);
+  });
+
+  it('accepts expiresAt as date string', () => {
+    const result = createInvitationSchema.parse({ expiresAt: '2026-12-31' });
+    assert.ok(result.expiresAt instanceof Date);
+  });
+
+  it('rejects maxUses of 0', () => {
+    assert.throws(() => createInvitationSchema.parse({ maxUses: 0 }));
+  });
+
+  it('rejects negative maxUses', () => {
+    assert.throws(() => createInvitationSchema.parse({ maxUses: -1 }));
+  });
+
+  it('rejects non-integer maxUses', () => {
+    assert.throws(() => createInvitationSchema.parse({ maxUses: 1.5 }));
+  });
+});
+
+// ─── registerWithInviteSchema ───────────────────────────────
+
+describe('registerWithInviteSchema', () => {
+  const validInput = {
+    token: 'abc-123',
+    name: 'Test User',
+    email: 'test@example.com',
+    password: 'securepassword',
+  };
+
+  it('accepts valid input', () => {
+    const result = registerWithInviteSchema.parse(validInput);
+    assert.equal(result.token, 'abc-123');
+    assert.equal(result.email, 'test@example.com');
+  });
+
+  it('rejects empty token', () => {
+    assert.throws(() => registerWithInviteSchema.parse({ ...validInput, token: '' }));
+  });
+
+  it('rejects empty name', () => {
+    assert.throws(() => registerWithInviteSchema.parse({ ...validInput, name: '' }));
+  });
+
+  it('rejects invalid email', () => {
+    assert.throws(() => registerWithInviteSchema.parse({ ...validInput, email: 'not-an-email' }));
+  });
+
+  it('rejects password shorter than 8 characters', () => {
+    assert.throws(() => registerWithInviteSchema.parse({ ...validInput, password: 'short' }));
+  });
+
+  it('accepts password of exactly 8 characters', () => {
+    const result = registerWithInviteSchema.parse({ ...validInput, password: '12345678' });
+    assert.equal(result.password, '12345678');
+  });
+
+  it('rejects missing fields', () => {
+    assert.throws(() => registerWithInviteSchema.parse({}));
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the register tab from the login page — login only, registration via invite links
- Add **Invitations** section to admin users page: create invitation dialog (max uses, expiration), copy-to-clipboard invite URLs, status badges (Active/Revoked/Expired/Fully Used), revoke with confirmation
- Extract `getInvitationDisplayStatus` helper for testability
- Add tests for Zod schemas (`createInvitationSchema`, `registerWithInviteSchema`) and display status logic

Closes #27

## Test plan

### Automated (35 tests passing)
- [x] `invitation.validation.test.ts` — token validation (null, revoked, expired, exhausted, priority order)
- [x] `invitation.types.test.ts` — Zod schemas: valid inputs, edge cases (maxUses=0, short password, invalid email)
- [x] `invitation.display-status.test.ts` — display status derivation, priority (revoked > expired > exhausted)

### Manual testing

**Login page:**
- [x] Visit `/login` — only email/password form shown, no register tab
- [x] Login still works as expected

**Create invitation (admin):**
- [x] Visit `/admin/users` as admin — "Create Invitation" button visible in Invitations section
- [x] Click "Create Invitation" — dialog opens with max uses and expiration fields
- [x] Submit with defaults (empty max uses, 30 days) — invite URL shown with copy button
- [x] Submit with max uses = 5 — creates correctly
- [x] Copy button copies URL to clipboard
- [x] Click "Done" — dialog closes, new invitation appears in the list

**Invitations list (admin):**
- [x] Active invitations show truncated token, uses count, expiry date, creator name
- [x] Active invitations have "Copy Link" and "Revoke" buttons
- [x] Revoke button shows confirmation dialog
- [x] After revoking — status changes to "Revoked", action buttons disappear
- [x] Expired invitations show "Expired" badge, no action buttons
- [x] Fully used invitations show "Fully Used" badge, no action buttons

**Registration flow (end-to-end):**
- [x] Open invite URL while logged out → registration form with inviter name
- [x] Register → account created, redirect to `/onboarding/languages`
- [x] Open same single-use URL again → "already been used" message
- [x] Open revoked invitation URL → "has been revoked" message
- [x] Open expired invitation URL → "has expired" message
- [x] Visit `/register/invalid-token` → "Invitation not found" message
- [x] Visit invite URL while logged in → redirect to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)