### PR TITLE
feat: make dev server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ pnpm dev
 
 Visit [http://localhost:3000](http://localhost:3000)
 
+By default the dev server runs on port 3000. To use a different port, set `PORT` in your `.env` file:
+
+```env
+PORT=4000
+```
+
+Or override it inline:
+
+```bash
+PORT=4000 pnpm dev
+```
+
 ## User Roles
 
 ### Translator (Default)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=20.18.1"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "set -a && . ./.env 2>/dev/null; set +a; next dev --port ${PORT:-3000}",
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary

- Make dev server port configurable via `PORT` env var to avoid conflicts with other local apps occupying port 3000
- Sources `.env` before starting Next.js so `PORT` is available to the shell
- Falls back to port 3000 when `PORT` is not set

## Usage

Set `PORT` in `.env` or override inline:
```sh
PORT=4000 pnpm dev
```

## Test plan

- [ ] `pnpm dev` starts on port 3000 when no `PORT` set
- [ ] `pnpm dev` starts on port from `.env` `PORT` value
- [ ] `PORT=5000 pnpm dev` overrides both defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)