### PR TITLE
feat: add MEETING document type

### DIFF
--- a/prisma/migrations/20260511120000_add_meeting_document_type/migration.sql
+++ b/prisma/migrations/20260511120000_add_meeting_document_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DocumentType" ADD VALUE 'MEETING';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ enum DocumentType {
   DAY
   FIELD_GUIDE
   DAILY_CONTENT
+  MEETING
 }
 
 enum GitHubPRStatus {

--- a/prisma/seed-data/content.ts
+++ b/prisma/seed-data/content.ts
@@ -212,6 +212,34 @@ This week I will pray especially for:
 ### Scripture to Carry
 Choose one verse to memorize or meditate on throughout the week:`,
 
+  'ea-m1': `---
+title: Easter Week 6 Meeting
+subtitle: May 10 - May 16
+caption: Easter
+sort_order: 4
+hero: meetings-easter_2026
+---
+
+# Easter Week 6 Meeting
+
+## Opening Prayer
+
+Risen Lord, gather us in Your peace as we share what You have done in our lives this week.
+
+## Scripture for Reflection
+
+> "Peace I leave with you; my peace I give to you. Not as the world gives do I give to you." — John 14:27
+
+## Group Discussion
+
+1. Where did you experience the Risen Christ this week?
+2. What invitation is the Lord offering you in this Easter season?
+3. How can the group support you in living out that invitation?
+
+## Closing
+
+End with the Regina Caeli and a moment of silent thanksgiving.`,
+
   'le-aw': `# Ash Wednesday Reflection
 
 > "Remember that you are dust, and to dust you shall return." — Genesis 3:19

--- a/prisma/seed-data/datasets.ts
+++ b/prisma/seed-data/datasets.ts
@@ -106,6 +106,13 @@ export const SOURCE_PROJECTS = [
     status: SourceProjectStatus.ACTIVE,
   },
   {
+    key: 'easter',
+    name: 'Easter 2026',
+    description: 'Weekly meeting guides for the Easter season — group reflection on Sunday readings.',
+    identifier: 'easter2026',
+    status: SourceProjectStatus.ACTIVE,
+  },
+  {
     key: 'retreat',
     name: 'Summer Retreat 2025',
     description: 'Weekend retreat materials including talks and small group guides.',
@@ -151,6 +158,8 @@ export const PROJECT_MEMBERS: { tp: string; user: string; role: ProjectRole }[] 
   { tp: 'lent:fr', user: 'admin2', role: ProjectRole.PROJECT_MANAGER },
   // Advent
   { tp: 'advent:cs', user: 'admin1', role: ProjectRole.PROJECT_MANAGER },
+  { tp: 'easter:cs', user: 'admin1', role: ProjectRole.PROJECT_MANAGER },
+  { tp: 'easter:cs', user: 'translator1', role: ProjectRole.TRANSLATOR },
   { tp: 'advent:cs', user: 'translator1', role: ProjectRole.TRANSLATOR },
   { tp: 'advent:sk', user: 'admin1', role: ProjectRole.PROJECT_MANAGER },
   { tp: 'advent:sk', user: 'reviewer1', role: ProjectRole.TRANSLATOR },
@@ -200,6 +209,8 @@ export const DOCUMENTS: {
   { key: 'ad-w1', slug: 'advent-week-1', title: 'First Week: Hope', type: DocumentType.DAY, labels: ['week-1'], project: 'advent' },
   { key: 'ad-w2', slug: 'advent-week-2', title: 'Second Week: Peace', type: DocumentType.DAY, labels: ['week-2'], project: 'advent' },
   { key: 'ad-fg', slug: 'advent-wreath-guide', title: 'Advent Wreath Guide', type: DocumentType.FIELD_GUIDE, labels: ['reference', 'family'], project: 'advent' },
+  // Easter
+  { key: 'ea-m1', slug: 'easter-week-6-meeting', title: 'Easter Week 6 Meeting', type: DocumentType.MEETING, labels: ['week-6', 'easter'], originalFilename: '1-7.md', project: 'easter' },
   // Summer Retreat
   { key: 're-t1', slug: 'retreat-opening-talk', title: 'Opening Talk: Finding Silence', type: DocumentType.DAILY_CONTENT, labels: ['talk', 'day-1'], project: 'retreat' },
 ];
@@ -271,6 +282,9 @@ export const TARGET_VERSIONS: VersionDef[] = [
   { docKey: 'ad-w1', langCode: 'sk', status: DocumentStatus.DEPLOYED, userKey: 'reviewer1', reviewerKey: 'admin1', versionNum: 5 },
   { docKey: 'ad-w2', langCode: 'sk', status: DocumentStatus.DEPLOYED, userKey: 'reviewer1', reviewerKey: 'admin1', versionNum: 5 },
 
+  // Easter
+  { docKey: 'ea-m1', langCode: 'cs', status: DocumentStatus.PENDING_TRANSLATION, userKey: 'admin1', versionNum: 1 },
+
   // Summer Retreat (all DEPLOYED)
   { docKey: 're-t1', langCode: 'cs', status: DocumentStatus.DEPLOYED, userKey: 'translator1', reviewerKey: 'admin1', versionNum: 5 },
   { docKey: 're-t1', langCode: 'sk', status: DocumentStatus.DEPLOYED, userKey: 'reviewer1', reviewerKey: 'admin1', versionNum: 5 },
@@ -318,6 +332,8 @@ export const DOCUMENT_ASSIGNMENTS: { docKey: string; langCode: string; userKey: 
   { docKey: 'le-fg', langCode: 'sk', userKey: 'reviewer1' },
   // Lent German
   { docKey: 'le-aw', langCode: 'de', userKey: 'translator2' },
+  // Easter
+  { docKey: 'ea-m1', langCode: 'cs', userKey: 'translator1' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -146,6 +146,7 @@ async function seedTranslationProjects(
     exodus: 'Exodus90 2026',
     lent: 'Lent 2026',
     advent: 'Advent 2025',
+    easter: 'Easter 2026',
     retreat: 'Summer Retreat 2025',
   };
   const langNames: Record<string, string> = {
@@ -307,6 +308,7 @@ async function seedDocumentAssignments(
     if (key.startsWith('ex-')) docToProject[key] = 'exodus';
     else if (key.startsWith('le-')) docToProject[key] = 'lent';
     else if (key.startsWith('ad-')) docToProject[key] = 'advent';
+    else if (key.startsWith('ea-')) docToProject[key] = 'easter';
     else if (key.startsWith('re-')) docToProject[key] = 'retreat';
   }
 

--- a/src/app/documents/[id]/edit/page.client.tsx
+++ b/src/app/documents/[id]/edit/page.client.tsx
@@ -10,6 +10,7 @@ import { DocumentTypeSelect } from '@/components/document-form/document-type-sel
 import { LabelsField } from '@/components/document-form/labels-field';
 import { OriginalFilenameField } from '@/components/document-form/original-filename-field';
 import { validateDailyContentFilename } from '@/components/document-form/validate-daily-content-filename';
+import { validateMeetingFilename } from '@/components/document-form/validate-meeting-filename';
 import { updateDocumentAction } from '@/domain/document/document.actions';
 import { updateDocumentVersionAction } from '@/domain/document-version/document-version.actions';
 import { ArrowLeft } from 'lucide-react';
@@ -50,7 +51,9 @@ export default function EditDocumentClient({ document, sourceVersion, sourceProj
   const [content, setContent] = useState(sourceVersion?.content || '');
   const [loading, setLoading] = useState(false);
 
-  const dailyContentFilenameError = validateDailyContentFilename(documentType, originalFilename);
+  const filenameError =
+    validateDailyContentFilename(documentType, originalFilename) ||
+    validateMeetingFilename(documentType, originalFilename);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -121,7 +124,7 @@ export default function EditDocumentClient({ document, sourceVersion, sourceProj
                   value={originalFilename}
                   onChange={setOriginalFilename}
                   documentType={documentType}
-                  error={dailyContentFilenameError}
+                  error={filenameError}
                 />
               </div>
 
@@ -166,7 +169,7 @@ export default function EditDocumentClient({ document, sourceVersion, sourceProj
                     Cancel
                   </Button>
                 </Link>
-                <Button type="submit" disabled={loading || !title || !!dailyContentFilenameError}>
+                <Button type="submit" disabled={loading || !title || !!filenameError}>
                   {loading ? 'Saving...' : 'Save Changes'}
                 </Button>
               </div>

--- a/src/app/documents/new/page.client.tsx
+++ b/src/app/documents/new/page.client.tsx
@@ -11,6 +11,7 @@ import { DocumentTypeSelect } from '@/components/document-form/document-type-sel
 import { LabelsField } from '@/components/document-form/labels-field';
 import { OriginalFilenameField } from '@/components/document-form/original-filename-field';
 import { validateDailyContentFilename } from '@/components/document-form/validate-daily-content-filename';
+import { validateMeetingFilename } from '@/components/document-form/validate-meeting-filename';
 import { createDocumentAction } from '@/domain/document/document.actions';
 import { createSourceProjectAction } from '@/domain/source-project/source-project.actions';
 import matter from 'gray-matter';
@@ -64,7 +65,9 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
   const [loading, setLoading] = useState(false);
   const [creatingProject, setCreatingProject] = useState(false);
 
-  const dailyContentFilenameError = validateDailyContentFilename(documentType, originalFilename);
+  const filenameError =
+    validateDailyContentFilename(documentType, originalFilename) ||
+    validateMeetingFilename(documentType, originalFilename);
 
   const processFile = useCallback((file: File) => {
     setOriginalFilename(file.name);
@@ -240,7 +243,7 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
                       value={originalFilename}
                       onChange={setOriginalFilename}
                       documentType={documentType}
-                      error={dailyContentFilenameError}
+                      error={filenameError}
                     />
                   </div>
 
@@ -355,7 +358,7 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
                     <Button
                       type="submit"
                       disabled={
-                        loading || !sourceProjectId || sourceProjects.length === 0 || !!dailyContentFilenameError
+                        loading || !sourceProjectId || sourceProjects.length === 0 || !!filenameError
                       }
                     >
                       {loading ? 'Creating...' : 'Create Document'}

--- a/src/components/document-form/document-type-select.tsx
+++ b/src/components/document-form/document-type-select.tsx
@@ -19,6 +19,7 @@ export function DocumentTypeSelect({ value, onChange }: DocumentTypeSelectProps)
         <SelectContent>
           <SelectItem value="DAY">Day</SelectItem>
           <SelectItem value="FIELD_GUIDE">Field Guide</SelectItem>
+          <SelectItem value="MEETING">Meeting</SelectItem>
           <SelectItem value="DAILY_CONTENT">Daily Content</SelectItem>
         </SelectContent>
       </Select>

--- a/src/components/document-form/original-filename-field.tsx
+++ b/src/components/document-form/original-filename-field.tsx
@@ -18,7 +18,13 @@ export function OriginalFilenameField({ value, onChange, documentType, error }: 
         id="originalFilename"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder={documentType === 'DAILY_CONTENT' ? 'e.g., 20260201-5.md' : 'e.g., 1.md'}
+        placeholder={
+          documentType === 'DAILY_CONTENT'
+            ? 'e.g., 20260201-5.md'
+            : documentType === 'MEETING'
+              ? 'e.g., 1-7.md'
+              : 'e.g., 1.md'
+        }
         className={error ? 'border-red-500' : ''}
       />
       {error ? (

--- a/src/components/document-form/validate-meeting-filename.ts
+++ b/src/components/document-form/validate-meeting-filename.ts
@@ -1,0 +1,13 @@
+export function validateMeetingFilename(documentType: string, originalFilename: string): string | null {
+  if (documentType !== 'MEETING') return null;
+
+  if (!originalFilename) {
+    return 'Meeting documents require a filename (e.g., "1-7.md")';
+  }
+
+  if (!/^\d+-\d+\.md$/.test(originalFilename)) {
+    return `Invalid filename "${originalFilename}". Expected format "N-N.md" (e.g., "1-7.md")`;
+  }
+
+  return null;
+}

--- a/src/domain/document/document.repository.ts
+++ b/src/domain/document/document.repository.ts
@@ -88,7 +88,7 @@ export async function createDocument(data: {
   labels: string[];
   deadline?: Date;
   originalFilename?: string;
-  type?: 'DAY' | 'FIELD_GUIDE' | 'DAILY_CONTENT';
+  type?: 'DAY' | 'FIELD_GUIDE' | 'DAILY_CONTENT' | 'MEETING';
 }): Promise<DocumentBasic> {
   return prisma.document.create({
     data: {
@@ -113,7 +113,7 @@ export async function updateDocument(
     folderId?: string | null; // Deprecated - kept for backward compatibility
     labels?: string[];
     deadline?: Date | null;
-    type?: 'DAY' | 'FIELD_GUIDE' | 'DAILY_CONTENT' | null;
+    type?: 'DAY' | 'FIELD_GUIDE' | 'DAILY_CONTENT' | 'MEETING' | null;
     originalFilename?: string | null;
   },
 ): Promise<DocumentBasic> {

--- a/src/domain/document/document.types.ts
+++ b/src/domain/document/document.types.ts
@@ -12,7 +12,7 @@ export const createDocumentSchema = z.object({
   labels: z.array(z.string()).default([]),
   deadline: z.coerce.date().optional(),
   originalFilename: z.string().optional(),
-  type: z.enum(['DAY', 'FIELD_GUIDE', 'DAILY_CONTENT']).optional(),
+  type: z.enum(['DAY', 'FIELD_GUIDE', 'DAILY_CONTENT', 'MEETING']).optional(),
 });
 
 export const updateDocumentSchema = z.object({
@@ -21,7 +21,7 @@ export const updateDocumentSchema = z.object({
   folderId: z.string().nullable().optional(), // Deprecated - kept for backward compatibility
   labels: z.array(z.string()).optional(),
   deadline: z.coerce.date().nullable().optional(),
-  type: z.enum(['DAY', 'FIELD_GUIDE', 'DAILY_CONTENT']).nullable().optional(),
+  type: z.enum(['DAY', 'FIELD_GUIDE', 'DAILY_CONTENT', 'MEETING']).nullable().optional(),
   originalFilename: z.string().nullable().optional(),
 });
 

--- a/src/domain/github/github.service.ts
+++ b/src/domain/github/github.service.ts
@@ -42,6 +42,10 @@ function resolveFilePath(params: FilePathParams): string {
       path = `translations/${languageCode}/exercises/${identifier}/field_guide/${filename}`;
       break;
 
+    case DocumentType.MEETING:
+      path = `translations/${languageCode}/exercises/${identifier}/meetings/${filename}`;
+      break;
+
     case DocumentType.DAILY_CONTENT: {
       const { year, month } = parseDailyContentDate(originalFilename);
       path = `translations/${languageCode}/daily_content/${year}/${month}/${filename}`;


### PR DESCRIPTION
## Summary

Adds a new `DocumentType` for meeting guide documents, deploying to `translations/[lang]/exercises/[identifier]/meetings/[filename]` (sibling of `days/` and `field_guide/`).

These guides were previously authored as `DAILY_CONTENT` in the destination app — going-forward only, no retroactive migration of existing rows.

## Changes

- **Schema**: `MEETING` added to `DocumentType` enum + Prisma migration (`ALTER TYPE … ADD VALUE 'MEETING'`)
- **Zod / TS unions**: `document.types.ts`, `document.repository.ts`
- **Deploy path**: new `case DocumentType.MEETING` in `github.service.ts:resolveFilePath`
- **UI**: `MEETING` option in `DocumentTypeSelect`, placeholder `e.g., 1-7.md` in `OriginalFilenameField`
- **Validation**: new `validate-meeting-filename.ts` enforces `^\d+-\d+\.md$`, wired into both the create and edit forms alongside the existing daily-content validator
- **Seed data**: Easter 2026 source project (`identifier: easter2026`) with one `MEETING` doc (`ea-m1`, filename `1-7.md`) — exercises the full flow end to end

## Follow-up

Adding a new `DocumentType` still touches ~7 files across schema, domain, service layer, and UI. Once the next type lands, this per-type wiring should be extracted into a single registry so adding a type becomes a one-line entry. Tracked separately in #55 to keep this diff focused on shipping MEETING.

## Test plan

- [ ] `prisma migrate dev` applies cleanly
- [ ] `prisma db seed` runs without errors; Easter project + MEETING doc appear in Documents overview
- [ ] Upload form: selecting type=Meeting + filename `1-7.md` submits successfully
- [ ] Upload form: selecting type=Meeting + filename `1.md` blocks submit with a clear error
- [ ] Edit form: same validation behavior
- [ ] Deploying a MEETING translation lands at `translations/{lang}/exercises/{identifier}/meetings/{filename}`