### PR TITLE
fix: restore admin invitation-management backend dropped by #52

### DIFF
--- a/src/app/admin/users/page.client.tsx
+++ b/src/app/admin/users/page.client.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/domain/invitation/invitation.display-status';
 import { authClient } from '@/lib/auth-client';
 import { Role, InvitationStatus } from '@prisma/client';
-import { Ban, Check, ChevronLeft, ChevronRight, Clock, Copy, Link2, Plus, Shield, Unlock, Users, X } from 'lucide-react';
+import { Ban, Check, ChevronLeft, ChevronRight, Clock, Copy, Link2, Plus, Shield, Unlock, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 

--- a/src/domain/invitation/invitation.actions.ts
+++ b/src/domain/invitation/invitation.actions.ts
@@ -1,9 +1,45 @@
 'use server';
 
+import crypto from 'node:crypto';
 import { auth } from '@/lib/auth';
-import { findInvitationByToken, incrementUsedCount, rollbackInvitationUse } from './invitation.repository';
-import { registerWithInviteSchema } from './invitation.types';
+import { authorize } from '@/lib/authorize';
+import {
+  createInvitation,
+  findInvitationByToken,
+  incrementUsedCount,
+  listInvitations,
+  revokeInvitation,
+  rollbackInvitationUse,
+} from './invitation.repository';
+import { createInvitationSchema, registerWithInviteSchema } from './invitation.types';
 import { validateInvitationToken } from './invitation.validation';
+
+const DEFAULT_EXPIRY_DAYS = 30;
+
+export async function createInvitationAction(input: unknown) {
+  const { user } = await authorize('admin');
+  const parsed = createInvitationSchema.parse(input);
+
+  const token = crypto.randomUUID();
+  const expiresAt = parsed.expiresAt ?? new Date(Date.now() + DEFAULT_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+
+  const invitation = await createInvitation(token, parsed.maxUses ?? null, expiresAt, user.id);
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const inviteUrl = `${baseUrl}/register/${invitation.token}`;
+
+  return { ...invitation, inviteUrl };
+}
+
+export async function listInvitationsAction() {
+  await authorize('admin');
+  return listInvitations();
+}
+
+export async function revokeInvitationAction(id: string) {
+  await authorize('admin');
+  return revokeInvitation(id);
+}
 
 export async function validateInvitationTokenAction(
   token: string,

--- a/src/domain/invitation/invitation.repository.ts
+++ b/src/domain/invitation/invitation.repository.ts
@@ -1,4 +1,42 @@
+import type { InvitationStatus } from '@prisma/client';
 import prisma from '@/lib/db';
+
+export async function createInvitation(
+  token: string,
+  maxUses: number | null,
+  expiresAt: Date,
+  createdById: string,
+) {
+  return prisma.invitation.create({
+    data: { token, maxUses, expiresAt, createdById },
+    select: {
+      id: true,
+      token: true,
+      maxUses: true,
+      expiresAt: true,
+      createdAt: true,
+    },
+  });
+}
+
+export async function listInvitations() {
+  return prisma.invitation.findMany({
+    include: {
+      createdBy: {
+        select: { id: true, name: true, email: true },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function revokeInvitation(id: string) {
+  return prisma.invitation.update({
+    where: { id },
+    data: { status: 'REVOKED' as InvitationStatus },
+    select: { id: true, status: true },
+  });
+}
 
 export async function findInvitationByToken(token: string) {
   return prisma.invitation.findUnique({

--- a/src/domain/invitation/invitation.types.ts
+++ b/src/domain/invitation/invitation.types.ts
@@ -1,8 +1,16 @@
 import { z } from 'zod';
 
+export const createInvitationSchema = z.object({
+  maxUses: z.number().int().min(1).nullable().optional().default(null),
+  expiresAt: z.coerce.date().optional(),
+});
+
 export const registerWithInviteSchema = z.object({
   token: z.string().min(1),
   name: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
 });
+
+export type CreateInvitationInput = z.infer<typeof createInvitationSchema>;
+export type RegisterWithInviteInput = z.infer<typeof registerWithInviteSchema>;


### PR DESCRIPTION
## Problem

`develop` does not compile and `pnpm test` is red. The **"chore: cleaning the code" PR (#52, commit `29c89b1`, I fcked up by cleaning)** deleted, as supposedly-dead code:

- `createInvitationAction`, `listInvitationsAction`, `revokeInvitationAction` (from `invitation.actions.ts`)
- `createInvitationSchema` + inferred types (from `invitation.types.ts`)
- `createInvitation`, `listInvitations`, `revokeInvitation` (from `invitation.repository.ts`)

But these are **not dead** — the admin users page still uses them:

- `src/app/admin/users/page.tsx` → `listInvitationsAction`
- `src/app/admin/users/page.client.tsx` → `createInvitationAction`, `revokeInvitationAction`
- `src/domain/invitation/invitation.types.test.ts` → `createInvitationSchema`

The result has been **5 `tsc` errors** and **4 failing tests** sitting on `develop` since #52 merged (likely uncaught because tests/`tsc` aren't gating merges — the `test` script even lists the failing `invitation.types.test.ts`).

## Fix

Partial revert of `29c89b1`: restore the removed actions, schema, and repository functions verbatim. All supporting infra (Prisma `Invitation` model + `InvitationStatus` enum, the `authorize('admin')` gateway) is intact, so it's a clean restore. Also drops a now-unused `Users` lucide import that was the 5th tsc error.

## Verification

- `tsc --noEmit` → **clean** (was 5 errors)
- `pnpm test` → **75/75 pass** (was 4 failing)
- `eslint` on the restored files → clean (the repo-wide `any` lint backlog is pre-existing and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)