### PR TITLE
fix: accept YAML files in document upload

### DIFF
--- a/src/app/documents/new/page.client.tsx
+++ b/src/app/documents/new/page.client.tsx
@@ -70,22 +70,38 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
 
   const processFile = useCallback((file: File) => {
     setOriginalFilename(file.name);
+    const isYaml = getContentFormat(file.name) === 'YAML';
 
     const reader = new FileReader();
     reader.onload = (event) => {
       const text = event.target?.result as string;
-      const { data: frontmatter } = matter(text);
+      // YAML documents often start with a `---` line, which gray-matter would
+      // misread as frontmatter and strip from the content — so skip it for YAML.
+      const { data: frontmatter } = isYaml ? { data: {} as Record<string, unknown> } : matter(text);
 
       setContent(text);
 
-      const extractedTitle = frontmatter.title || file.name.replace('.md', '');
-      setTitle(extractedTitle);
-      setSlug(generateSlug(extractedTitle));
+      const extractedTitle = frontmatter.title || file.name.replace(/\.(md|ya?ml)$/i, '');
+      setTitle(String(extractedTitle));
+      setSlug(generateSlug(String(extractedTitle)));
       setLabels(extractLabelsFromFrontmatter(frontmatter));
+      if (isYaml) setDocumentType('ROOT_FILE');
       setMode('create');
     };
     reader.readAsText(file);
   }, []);
+
+  const acceptFile = useCallback(
+    (file: File | undefined) => {
+      if (!file) return;
+      if (!/\.(md|ya?ml)$/i.test(file.name)) {
+        toast.error(`"${file.name}" is not supported. Upload a .md, .yml or .yaml file.`);
+        return;
+      }
+      processFile(file);
+    },
+    [processFile],
+  );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -101,15 +117,13 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
     (e: React.DragEvent) => {
       e.preventDefault();
       setIsDragging(false);
-      const file = e.dataTransfer.files[0];
-      if (file && file.name.endsWith('.md')) processFile(file);
+      acceptFile(e.dataTransfer.files[0]);
     },
-    [processFile],
+    [acceptFile],
   );
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file && file.name.endsWith('.md')) processFile(file);
+    acceptFile(e.target.files?.[0]);
   };
 
   const handleTitleChange = (value: string) => {
@@ -179,7 +193,7 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
       <div className="border-b bg-white">
         <div className="container mx-auto px-4 py-4">
           <h1 className="text-2xl font-bold">New Document</h1>
-          <p className="text-gray-600">Upload a markdown file or create a new document</p>
+          <p className="text-gray-600">Upload a markdown or YAML file, or create a new document</p>
         </div>
       </div>
 
@@ -211,15 +225,15 @@ export default function NewDocumentClient({ sourceProjects: initialSourceProject
                   `}
                 >
                   <Upload className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                  <p className="text-lg font-medium mb-2">Drag and drop your markdown file here</p>
+                  <p className="text-lg font-medium mb-2">Drag and drop your markdown or YAML file here</p>
                   <p className="text-gray-600 mb-4">or</p>
                   <label>
-                    <input type="file" accept=".md" onChange={handleFileSelect} className="hidden" />
+                    <input type="file" accept=".md,.yml,.yaml" onChange={handleFileSelect} className="hidden" />
                     <Button type="button" variant="outline" asChild>
                       <span>Browse Files</span>
                     </Button>
                   </label>
-                  <p className="text-xs text-gray-500 mt-4">Only .md files are supported</p>
+                  <p className="text-xs text-gray-500 mt-4">Supported files: .md, .yml, .yaml</p>
                 </div>
               </div>
             </TabsContent>


### PR DESCRIPTION
## Summary
- The upload flow at `/documents/new` only accepted `.md` files: the file picker had `accept=".md"` and both the drop handler and file-select **silently ignored** anything else. YAML root files (`disciplines.yml`, `metadata.yml`) could not be uploaded at all, so users renamed them to `*_yml.md` locally — and the deploy then faithfully committed `disciplines_yml.md` to GitHub (see support ticket: "deploy renames yml files to .md").
- The deploy itself never renames files — `resolveFilePath` uses `originalFilename` verbatim. The upload gate was the culprit.

## Changes
- Accept `.md`, `.yml`, `.yaml` in the file picker, drag-and-drop, and file-select
- Show an error toast for unsupported files instead of silently doing nothing
- Skip gray-matter frontmatter parsing for YAML files (a leading `---` would be misread as frontmatter and stripped from the content)
- Pre-select the **Root File** document type for YAML uploads (the only type where YAML applies)
- Derive the title by stripping any supported extension, not just `.md`

## Test plan
- [x] `pnpm test` — 119/119 pass
- [ ] Manual: upload `disciplines.yml` → lands in create form with Root File type pre-selected, original filename `disciplines.yml`, content intact
- [ ] Manual: drop a `.txt` file → error toast shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)