### PR TITLE
feat: in-app announcements (banner/modal with CTA)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/announcement/announcement.visibility.test.ts",
+    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/announcement/announcement.visibility.test.ts src/domain/announcement/announcement.types.test.ts",
     "db:seed": "tsx prisma/seed.ts",
     "format": "prettier --write .",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts",
+    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/announcement/announcement.visibility.test.ts",
     "db:seed": "tsx prisma/seed.ts",
     "format": "prettier --write .",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",

--- a/prisma/migrations/20260721120000_add_announcements/migration.sql
+++ b/prisma/migrations/20260721120000_add_announcements/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "AnnouncementType" AS ENUM ('BANNER', 'MODAL');
+
+-- CreateTable
+CREATE TABLE "announcement" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "type" "AnnouncementType" NOT NULL,
+    "ctaLabel" TEXT,
+    "ctaUrl" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "announcement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "announcement_dismissal" (
+    "id" TEXT NOT NULL,
+    "announcementId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "announcement_dismissal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "announcement_dismissal_announcementId_userId_key" ON "announcement_dismissal"("announcementId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "announcement_dismissal" ADD CONSTRAINT "announcement_dismissal_announcementId_fkey" FOREIGN KEY ("announcementId") REFERENCES "announcement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "announcement_dismissal" ADD CONSTRAINT "announcement_dismissal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/migrations/20260723120000_make_announcement_body_nullable/migration.sql
+++ b/prisma/migrations/20260723120000_make_announcement_body_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "announcement" ALTER COLUMN "body" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,11 @@ enum GitHubPRStatus {
   CLOSED
 }
 
+enum AnnouncementType {
+  BANNER
+  MODAL
+}
+
 model User {
   id                  String               @id @default(uuid())
   email               String               @unique
@@ -112,6 +117,7 @@ model User {
   suggestions         Suggestion[]
   suggestionReplies   SuggestionReply[]
   invitationsCreated  Invitation[]     @relation("InvitationsCreated")
+  announcementDismissals AnnouncementDismissal[]
 
   @@map("user")
 }
@@ -412,6 +418,34 @@ model Invitation {
   updatedAt   DateTime             @updatedAt
 
   @@map("invitation")
+}
+
+model Announcement {
+  id         String                  @id @default(uuid())
+  title      String
+  body       String                  @db.Text // Markdown content
+  type       AnnouncementType
+  ctaLabel   String?
+  ctaUrl     String?
+  isActive   Boolean                 @default(false)
+  expiresAt  DateTime?
+  createdAt  DateTime                @default(now())
+  updatedAt  DateTime                @updatedAt
+  dismissals AnnouncementDismissal[]
+
+  @@map("announcement")
+}
+
+model AnnouncementDismissal {
+  id             String       @id @default(uuid())
+  announcementId String
+  announcement   Announcement @relation(fields: [announcementId], references: [id], onDelete: Cascade)
+  userId         String
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt      DateTime     @default(now())
+
+  @@unique([announcementId, userId])
+  @@map("announcement_dismissal")
 }
 
 model InvitationLanguage {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -423,7 +423,7 @@ model Invitation {
 model Announcement {
   id         String                  @id @default(uuid())
   title      String
-  body       String                  @db.Text // Markdown content
+  body       String?                 @db.Text // Markdown content; modal-only (banners show just the title)
   type       AnnouncementType
   ctaLabel   String?
   ctaUrl     String?

--- a/src/app/admin/announcements/page.client.tsx
+++ b/src/app/admin/announcements/page.client.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import { AnnouncementType, type Announcement } from '@prisma/client';
+import { DeleteConfirmDialog } from '@/components/admin-list-page';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -9,14 +8,15 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { ArrowLeft, Edit, EyeOff, Megaphone, MessageSquare, Plus } from 'lucide-react';
-import { DeleteConfirmDialog } from '@/components/admin-list-page';
 import {
   createAnnouncementAction,
   deleteAnnouncementAction,
   toggleAnnouncementActiveAction,
   updateAnnouncementAction,
 } from '@/domain/announcement/announcement.actions';
+import { AnnouncementType, type Announcement } from '@prisma/client';
+import { ArrowLeft, Edit, EyeOff, Megaphone, MessageSquare, Plus } from 'lucide-react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 type AnnouncementWithCount = Announcement & { _count: { dismissals: number } };
@@ -96,9 +96,7 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
     try {
       if (editing) {
         const updated = await updateAnnouncementAction(editing.id, input);
-        setAnnouncements(
-          announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)),
-        );
+        setAnnouncements(announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)));
         toast.success('Announcement updated');
       } else {
         const created = await createAnnouncementAction(input);
@@ -119,9 +117,7 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
   const handleToggleActive = async (announcement: AnnouncementWithCount) => {
     try {
       const updated = await toggleAnnouncementActiveAction(announcement.id, !announcement.isActive);
-      setAnnouncements(
-        announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)),
-      );
+      setAnnouncements(announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)));
       toast.success(updated.isActive ? 'Announcement activated' : 'Announcement deactivated');
     } catch (error) {
       console.error('Error toggling announcement:', error);
@@ -222,9 +218,7 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
                   }
                   required
                 />
-                {type === 'BANNER' && (
-                  <p className="text-xs text-gray-500 mt-1">Banners show only this one line</p>
-                )}
+                {type === 'BANNER' && <p className="text-xs text-gray-500 mt-1">Banners show only this one line</p>}
               </div>
               {type === 'MODAL' && (
                 <div>
@@ -310,43 +304,49 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
                 <div className="grid gap-4">
                   {items.map((announcement) => (
                     <Card key={announcement.id} className="p-4">
-              <div className="flex items-start justify-between gap-4">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="font-semibold text-lg">{announcement.title}</h3>
-                    <Badge variant="outline">
-                      {announcement.type === 'BANNER' ? (
-                        <Megaphone className="h-3 w-3 mr-1" />
-                      ) : (
-                        <MessageSquare className="h-3 w-3 mr-1" />
-                      )}
-                      {announcement.type === 'BANNER' ? 'Banner' : 'Modal'}
-                    </Badge>
-                    {announcement.isActive && isExpired(announcement) && (
-                      <Badge variant="secondary">Expired</Badge>
-                    )}
-                  </div>
-                  {announcement.body && (
-                    <p className="text-sm text-gray-600 mt-1 line-clamp-2 whitespace-pre-line">{announcement.body}</p>
-                  )}
-                  <div className="flex flex-wrap gap-3 text-xs text-gray-500 mt-2">
-                    {announcement.ctaLabel && announcement.ctaUrl && <span>CTA: {announcement.ctaLabel}</span>}
-                    {announcement.expiresAt && (
-                      <span>Expires: {new Date(announcement.expiresAt).toLocaleString()}</span>
-                    )}
-                    <span>
-                      <EyeOff className="inline h-3 w-3 mr-0.5" aria-hidden="true" />
-                      {announcement._count.dismissals} dismissed
-                    </span>
-                  </div>
-                </div>
-                <div className="flex shrink-0 gap-2">
-                  <Button variant="outline" size="sm" onClick={() => handleToggleActive(announcement)}>
-                    {announcement.isActive ? 'Deactivate' : 'Activate'}
-                  </Button>
-                  <Button variant="outline" size="sm" onClick={() => handleEdit(announcement)}>
-                    <Edit className="h-4 w-4" />
-                  </Button>
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="font-semibold text-lg">{announcement.title}</h3>
+                            <Badge variant="outline">
+                              {announcement.type === 'BANNER' ? (
+                                <Megaphone className="h-3 w-3 mr-1" />
+                              ) : (
+                                <MessageSquare className="h-3 w-3 mr-1" />
+                              )}
+                              {announcement.type === 'BANNER' ? 'Banner' : 'Modal'}
+                            </Badge>
+                            {announcement.isActive && isExpired(announcement) && (
+                              <Badge variant="secondary">Expired</Badge>
+                            )}
+                          </div>
+                          {announcement.body && (
+                            <p className="text-sm text-gray-600 mt-1 line-clamp-2 whitespace-pre-line">
+                              {announcement.body}
+                            </p>
+                          )}
+                          <div className="flex flex-wrap gap-3 text-xs text-gray-500 mt-2">
+                            {announcement.ctaLabel && announcement.ctaUrl && <span>CTA: {announcement.ctaLabel}</span>}
+                            {announcement.expiresAt && (
+                              <span>Expires: {new Date(announcement.expiresAt).toLocaleString()}</span>
+                            )}
+                            <span>
+                              <EyeOff className="inline h-3 w-3 mr-0.5" aria-hidden="true" />
+                              {announcement._count.dismissals} dismissed
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 gap-2">
+                          <Button
+                            variant={announcement.isActive ? 'outline' : 'default'}
+                            size="sm"
+                            onClick={() => handleToggleActive(announcement)}
+                          >
+                            {announcement.isActive ? 'Deactivate' : 'Activate'}
+                          </Button>
+                          <Button variant="outline" size="sm" onClick={() => handleEdit(announcement)}>
+                            <Edit className="h-4 w-4" />
+                          </Button>
                           <DeleteConfirmDialog
                             title="Delete Announcement"
                             description={`Are you sure you want to delete "${announcement.title}"? This action cannot be undone.`}

--- a/src/app/admin/announcements/page.client.tsx
+++ b/src/app/admin/announcements/page.client.tsx
@@ -164,6 +164,9 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
               rows={5}
               required
             />
+            <p className="text-xs text-gray-500 mt-1">
+              Shown in modals only — banners are one-liners displaying just the title
+            </p>
           </div>
           <div>
             <Label htmlFor="type">Display as *</Label>
@@ -172,8 +175,8 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="BANNER">Banner (top of dashboard)</SelectItem>
-                <SelectItem value="MODAL">Modal (dialog on dashboard load)</SelectItem>
+                <SelectItem value="BANNER">Banner (one-line bar, title only)</SelectItem>
+                <SelectItem value="MODAL">Modal (dialog with full body)</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/app/admin/announcements/page.client.tsx
+++ b/src/app/admin/announcements/page.client.tsx
@@ -5,12 +5,12 @@ import { AnnouncementType, type Announcement } from '@prisma/client';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { Edit, EyeOff, Megaphone, MessageSquare } from 'lucide-react';
-import { AdminListPage, DeleteConfirmDialog } from '@/components/admin-list-page';
+import { ArrowLeft, Edit, EyeOff, Megaphone, MessageSquare, Plus } from 'lucide-react';
+import { DeleteConfirmDialog } from '@/components/admin-list-page';
 import {
   createAnnouncementAction,
   deleteAnnouncementAction,
@@ -35,6 +35,7 @@ function toDatetimeLocalValue(date: Date | null): string {
 export default function AnnouncementsClient({ announcements: initialAnnouncements }: AnnouncementsClientProps) {
   const [announcements, setAnnouncements] = useState(initialAnnouncements);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [step, setStep] = useState<'type' | 'form'>('type');
   const [editing, setEditing] = useState<AnnouncementWithCount | null>(null);
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
@@ -45,6 +46,7 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
   const [loading, setLoading] = useState(false);
 
   const resetForm = () => {
+    setStep('type');
     setEditing(null);
     setTitle('');
     setBody('');
@@ -54,13 +56,35 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
     setExpiresAt('');
   };
 
+  const openCreate = () => {
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (announcement: AnnouncementWithCount) => {
+    setEditing(announcement);
+    setTitle(announcement.title);
+    setBody(announcement.body || '');
+    setType(announcement.type);
+    setCtaLabel(announcement.ctaLabel || '');
+    setCtaUrl(announcement.ctaUrl || '');
+    setExpiresAt(toDatetimeLocalValue(announcement.expiresAt));
+    setStep('form');
+    setDialogOpen(true);
+  };
+
+  const chooseType = (chosen: AnnouncementType) => {
+    setType(chosen);
+    setStep('form');
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
 
     const input = {
       title,
-      body,
+      body: type === 'MODAL' ? body : null,
       type,
       ctaLabel: ctaLabel || null,
       ctaUrl: ctaUrl || null,
@@ -91,17 +115,6 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
     }
   };
 
-  const handleEdit = (announcement: AnnouncementWithCount) => {
-    setEditing(announcement);
-    setTitle(announcement.title);
-    setBody(announcement.body);
-    setType(announcement.type);
-    setCtaLabel(announcement.ctaLabel || '');
-    setCtaUrl(announcement.ctaUrl || '');
-    setExpiresAt(toDatetimeLocalValue(announcement.expiresAt));
-    setDialogOpen(true);
-  };
-
   const handleToggleActive = async (announcement: AnnouncementWithCount) => {
     try {
       const updated = await toggleAnnouncementActiveAction(announcement.id, !announcement.isActive);
@@ -129,139 +142,213 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
   const isExpired = (announcement: AnnouncementWithCount) =>
     announcement.expiresAt !== null && new Date(announcement.expiresAt).getTime() <= Date.now();
 
+  const dialogTitle = editing
+    ? `Edit ${type === 'BANNER' ? 'Banner' : 'Modal'}`
+    : step === 'type'
+      ? 'New Announcement'
+      : `New ${type === 'BANNER' ? 'Banner' : 'Modal'}`;
+
   return (
-    <AdminListPage
-      title="Announcements"
-      description="Notify users about new functionality or ask for their input"
-      addLabel="Add Announcement"
-      dialogOpen={dialogOpen}
-      onDialogOpenChange={(open) => {
-        setDialogOpen(open);
-        if (!open) resetForm();
-      }}
-      dialogTitle={editing ? 'Edit Announcement' : 'Add Announcement'}
-      onSubmit={handleSubmit}
-      loading={loading}
-      formFields={
-        <>
-          <div>
-            <Label htmlFor="title">Title *</Label>
-            <Input
-              id="title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g., New review workflow is live"
-              required
-            />
-          </div>
-          <div>
-            <Label htmlFor="body">Body (markdown) *</Label>
-            <Textarea
-              id="body"
-              value={body}
-              onChange={(e) => setBody(e.target.value)}
-              placeholder={'We shipped **something new**…'}
-              rows={5}
-              required
-            />
-            <p className="text-xs text-gray-500 mt-1">
-              Shown in modals only — banners are one-liners displaying just the title
-            </p>
-          </div>
-          <div>
-            <Label htmlFor="type">Display as *</Label>
-            <Select value={type} onValueChange={(value) => setType(value as AnnouncementType)}>
-              <SelectTrigger id="type">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="BANNER">Banner (one-line bar, title only)</SelectItem>
-                <SelectItem value="MODAL">Modal (dialog with full body)</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
+    <div className="min-h-screen bg-gray-50">
+      <div className="border-b bg-white">
+        <div className="container mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
             <div>
-              <Label htmlFor="ctaLabel">CTA Label</Label>
-              <Input
-                id="ctaLabel"
-                value={ctaLabel}
-                onChange={(e) => setCtaLabel(e.target.value)}
-                placeholder="e.g., Fill out survey"
-              />
+              <h1 className="text-2xl font-bold">Announcements</h1>
+              <p className="text-gray-600">Notify users about new functionality or ask for their input</p>
             </div>
-            <div>
-              <Label htmlFor="ctaUrl">CTA URL</Label>
-              <Input
-                id="ctaUrl"
-                value={ctaUrl}
-                onChange={(e) => setCtaUrl(e.target.value)}
-                placeholder="https://forms.google.com/…"
-              />
-            </div>
+            <Button onClick={openCreate}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Announcement
+            </Button>
           </div>
-          <div>
-            <Label htmlFor="expiresAt">Expires At</Label>
-            <Input
-              id="expiresAt"
-              type="datetime-local"
-              value={expiresAt}
-              onChange={(e) => setExpiresAt(e.target.value)}
-            />
-            <p className="text-xs text-gray-500 mt-1">Optional — stops showing automatically after this time</p>
-          </div>
-        </>
-      }
-    >
-      {announcements.length === 0 && (
-        <p className="text-sm text-gray-500">No announcements yet. Create one to notify users.</p>
-      )}
-      {announcements.map((announcement) => (
-        <Card key={announcement.id} className="p-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <h3 className="font-semibold text-lg">{announcement.title}</h3>
-                <Badge variant="outline">
-                  {announcement.type === 'BANNER' ? (
-                    <Megaphone className="h-3 w-3 mr-1" />
-                  ) : (
-                    <MessageSquare className="h-3 w-3 mr-1" />
-                  )}
-                  {announcement.type === 'BANNER' ? 'Banner' : 'Modal'}
-                </Badge>
-                {announcement.isActive && !isExpired(announcement) && <Badge>Active</Badge>}
-                {announcement.isActive && isExpired(announcement) && <Badge variant="secondary">Expired</Badge>}
-                {!announcement.isActive && <Badge variant="secondary">Inactive</Badge>}
-              </div>
-              <p className="text-sm text-gray-600 mt-1 line-clamp-2 whitespace-pre-line">{announcement.body}</p>
-              <div className="flex flex-wrap gap-3 text-xs text-gray-500 mt-2">
-                {announcement.ctaLabel && announcement.ctaUrl && <span>CTA: {announcement.ctaLabel}</span>}
-                {announcement.expiresAt && (
-                  <span>Expires: {new Date(announcement.expiresAt).toLocaleString()}</span>
-                )}
+        </div>
+      </div>
+
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) resetForm();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{dialogTitle}</DialogTitle>
+          </DialogHeader>
+
+          {step === 'type' ? (
+            <div className="grid gap-3">
+              <button
+                type="button"
+                onClick={() => chooseType('BANNER')}
+                className="flex items-start gap-3 rounded-lg border p-4 text-left transition-colors hover:border-primary hover:bg-primary/5"
+              >
+                <Megaphone className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
                 <span>
-                  <EyeOff className="inline h-3 w-3 mr-0.5" aria-hidden="true" />
-                  {announcement._count.dismissals} dismissed
+                  <span className="block font-semibold">Banner</span>
+                  <span className="block text-sm text-gray-600">
+                    One-line bar at the top of the dashboard. Shows just the title — good for short nudges.
+                  </span>
                 </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => chooseType('MODAL')}
+                className="flex items-start gap-3 rounded-lg border p-4 text-left transition-colors hover:border-primary hover:bg-primary/5"
+              >
+                <MessageSquare className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+                <span>
+                  <span className="block font-semibold">Modal</span>
+                  <span className="block text-sm text-gray-600">
+                    Dialog on dashboard load with a full markdown body — for bigger news that needs explanation.
+                  </span>
+                </span>
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <Label htmlFor="title">Title *</Label>
+                <Input
+                  id="title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={
+                    type === 'BANNER'
+                      ? 'e.g., New review workflow is live — check it out!'
+                      : 'e.g., New review workflow'
+                  }
+                  required
+                />
+                {type === 'BANNER' && (
+                  <p className="text-xs text-gray-500 mt-1">Banners show only this one line</p>
+                )}
               </div>
-            </div>
-            <div className="flex shrink-0 gap-2">
-              <Button variant="outline" size="sm" onClick={() => handleToggleActive(announcement)}>
-                {announcement.isActive ? 'Deactivate' : 'Activate'}
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => handleEdit(announcement)}>
-                <Edit className="h-4 w-4" />
-              </Button>
-              <DeleteConfirmDialog
-                title="Delete Announcement"
-                description={`Are you sure you want to delete "${announcement.title}"? This action cannot be undone.`}
-                onConfirm={() => handleDelete(announcement.id)}
-              />
-            </div>
-          </div>
-        </Card>
-      ))}
-    </AdminListPage>
+              {type === 'MODAL' && (
+                <div>
+                  <Label htmlFor="body">Body (markdown) *</Label>
+                  <Textarea
+                    id="body"
+                    value={body}
+                    onChange={(e) => setBody(e.target.value)}
+                    placeholder={'We shipped **something new**…'}
+                    rows={5}
+                    required
+                  />
+                </div>
+              )}
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label htmlFor="ctaLabel">CTA Label</Label>
+                  <Input
+                    id="ctaLabel"
+                    value={ctaLabel}
+                    onChange={(e) => setCtaLabel(e.target.value)}
+                    placeholder="e.g., Fill out survey"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="ctaUrl">CTA URL</Label>
+                  <Input
+                    id="ctaUrl"
+                    value={ctaUrl}
+                    onChange={(e) => setCtaUrl(e.target.value)}
+                    placeholder="https://forms.google.com/…"
+                  />
+                </div>
+              </div>
+              <div>
+                <Label htmlFor="expiresAt">Expires At</Label>
+                <Input
+                  id="expiresAt"
+                  type="datetime-local"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                />
+                <p className="text-xs text-gray-500 mt-1">Optional — stops showing automatically after this time</p>
+              </div>
+              <div className="flex items-center justify-between">
+                <Button type="button" variant="ghost" size="sm" onClick={() => setStep('type')}>
+                  <ArrowLeft className="h-4 w-4 mr-1" />
+                  Change type
+                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setDialogOpen(false);
+                      resetForm();
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={loading}>
+                    {loading ? 'Saving...' : 'Save'}
+                  </Button>
+                </div>
+              </div>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <div className="container mx-auto px-4 py-4">
+        <div className="grid gap-4">
+          {announcements.length === 0 && (
+            <p className="text-sm text-gray-500">No announcements yet. Create one to notify users.</p>
+          )}
+          {announcements.map((announcement) => (
+            <Card key={announcement.id} className="p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-semibold text-lg">{announcement.title}</h3>
+                    <Badge variant="outline">
+                      {announcement.type === 'BANNER' ? (
+                        <Megaphone className="h-3 w-3 mr-1" />
+                      ) : (
+                        <MessageSquare className="h-3 w-3 mr-1" />
+                      )}
+                      {announcement.type === 'BANNER' ? 'Banner' : 'Modal'}
+                    </Badge>
+                    {announcement.isActive && !isExpired(announcement) && <Badge>Active</Badge>}
+                    {announcement.isActive && isExpired(announcement) && <Badge variant="secondary">Expired</Badge>}
+                    {!announcement.isActive && <Badge variant="secondary">Inactive</Badge>}
+                  </div>
+                  {announcement.body && (
+                    <p className="text-sm text-gray-600 mt-1 line-clamp-2 whitespace-pre-line">{announcement.body}</p>
+                  )}
+                  <div className="flex flex-wrap gap-3 text-xs text-gray-500 mt-2">
+                    {announcement.ctaLabel && announcement.ctaUrl && <span>CTA: {announcement.ctaLabel}</span>}
+                    {announcement.expiresAt && (
+                      <span>Expires: {new Date(announcement.expiresAt).toLocaleString()}</span>
+                    )}
+                    <span>
+                      <EyeOff className="inline h-3 w-3 mr-0.5" aria-hidden="true" />
+                      {announcement._count.dismissals} dismissed
+                    </span>
+                  </div>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <Button variant="outline" size="sm" onClick={() => handleToggleActive(announcement)}>
+                    {announcement.isActive ? 'Deactivate' : 'Activate'}
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => handleEdit(announcement)}>
+                    <Edit className="h-4 w-4" />
+                  </Button>
+                  <DeleteConfirmDialog
+                    title="Delete Announcement"
+                    description={`Are you sure you want to delete "${announcement.title}"? This action cannot be undone.`}
+                    onConfirm={() => handleDelete(announcement.id)}
+                  />
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/app/admin/announcements/page.client.tsx
+++ b/src/app/admin/announcements/page.client.tsx
@@ -89,7 +89,8 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
       ctaLabel: ctaLabel || null,
       ctaUrl: ctaUrl || null,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
-      isActive: editing?.isActive ?? false,
+      // New announcements go live immediately; edits keep the current state.
+      isActive: editing?.isActive ?? true,
     };
 
     try {
@@ -102,7 +103,7 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
       } else {
         const created = await createAnnouncementAction(input);
         setAnnouncements([{ ...created, _count: { dismissals: 0 } }, ...announcements]);
-        toast.success('Announcement created (inactive — activate it to publish)');
+        toast.success('Announcement created and live');
       }
 
       setDialogOpen(false);
@@ -294,13 +295,21 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
         </DialogContent>
       </Dialog>
 
-      <div className="container mx-auto px-4 py-4">
-        <div className="grid gap-4">
-          {announcements.length === 0 && (
-            <p className="text-sm text-gray-500">No announcements yet. Create one to notify users.</p>
-          )}
-          {announcements.map((announcement) => (
-            <Card key={announcement.id} className="p-4">
+      <div className="container mx-auto px-4 py-4 space-y-6">
+        {announcements.length === 0 && (
+          <p className="text-sm text-gray-500">No announcements yet. Create one to notify users.</p>
+        )}
+        {[
+          { heading: 'Active', items: announcements.filter((a) => a.isActive) },
+          { heading: 'Deactivated', items: announcements.filter((a) => !a.isActive) },
+        ].map(
+          ({ heading, items }) =>
+            items.length > 0 && (
+              <section key={heading}>
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-2">{heading}</h2>
+                <div className="grid gap-4">
+                  {items.map((announcement) => (
+                    <Card key={announcement.id} className="p-4">
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
@@ -313,9 +322,9 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
                       )}
                       {announcement.type === 'BANNER' ? 'Banner' : 'Modal'}
                     </Badge>
-                    {announcement.isActive && !isExpired(announcement) && <Badge>Active</Badge>}
-                    {announcement.isActive && isExpired(announcement) && <Badge variant="secondary">Expired</Badge>}
-                    {!announcement.isActive && <Badge variant="secondary">Inactive</Badge>}
+                    {announcement.isActive && isExpired(announcement) && (
+                      <Badge variant="secondary">Expired</Badge>
+                    )}
                   </div>
                   {announcement.body && (
                     <p className="text-sm text-gray-600 mt-1 line-clamp-2 whitespace-pre-line">{announcement.body}</p>
@@ -338,16 +347,19 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
                   <Button variant="outline" size="sm" onClick={() => handleEdit(announcement)}>
                     <Edit className="h-4 w-4" />
                   </Button>
-                  <DeleteConfirmDialog
-                    title="Delete Announcement"
-                    description={`Are you sure you want to delete "${announcement.title}"? This action cannot be undone.`}
-                    onConfirm={() => handleDelete(announcement.id)}
-                  />
+                          <DeleteConfirmDialog
+                            title="Delete Announcement"
+                            description={`Are you sure you want to delete "${announcement.title}"? This action cannot be undone.`}
+                            onConfirm={() => handleDelete(announcement.id)}
+                          />
+                        </div>
+                      </div>
+                    </Card>
+                  ))}
                 </div>
-              </div>
-            </Card>
-          ))}
-        </div>
+              </section>
+            ),
+        )}
       </div>
     </div>
   );

--- a/src/app/admin/announcements/page.client.tsx
+++ b/src/app/admin/announcements/page.client.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useState } from 'react';
+import { AnnouncementType, type Announcement } from '@prisma/client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Edit, EyeOff, Megaphone, MessageSquare } from 'lucide-react';
+import { AdminListPage, DeleteConfirmDialog } from '@/components/admin-list-page';
+import {
+  createAnnouncementAction,
+  deleteAnnouncementAction,
+  toggleAnnouncementActiveAction,
+  updateAnnouncementAction,
+} from '@/domain/announcement/announcement.actions';
+import { toast } from 'sonner';
+
+type AnnouncementWithCount = Announcement & { _count: { dismissals: number } };
+
+interface AnnouncementsClientProps {
+  announcements: AnnouncementWithCount[];
+}
+
+function toDatetimeLocalValue(date: Date | null): string {
+  if (!date) return '';
+  const d = new Date(date);
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+}
+
+export default function AnnouncementsClient({ announcements: initialAnnouncements }: AnnouncementsClientProps) {
+  const [announcements, setAnnouncements] = useState(initialAnnouncements);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<AnnouncementWithCount | null>(null);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [type, setType] = useState<AnnouncementType>('BANNER');
+  const [ctaLabel, setCtaLabel] = useState('');
+  const [ctaUrl, setCtaUrl] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const resetForm = () => {
+    setEditing(null);
+    setTitle('');
+    setBody('');
+    setType('BANNER');
+    setCtaLabel('');
+    setCtaUrl('');
+    setExpiresAt('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    const input = {
+      title,
+      body,
+      type,
+      ctaLabel: ctaLabel || null,
+      ctaUrl: ctaUrl || null,
+      expiresAt: expiresAt ? new Date(expiresAt) : null,
+      isActive: editing?.isActive ?? false,
+    };
+
+    try {
+      if (editing) {
+        const updated = await updateAnnouncementAction(editing.id, input);
+        setAnnouncements(
+          announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)),
+        );
+        toast.success('Announcement updated');
+      } else {
+        const created = await createAnnouncementAction(input);
+        setAnnouncements([{ ...created, _count: { dismissals: 0 } }, ...announcements]);
+        toast.success('Announcement created (inactive — activate it to publish)');
+      }
+
+      setDialogOpen(false);
+      resetForm();
+    } catch (error: any) {
+      console.error('Error saving announcement:', error);
+      toast.error(error.message || 'Failed to save announcement');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (announcement: AnnouncementWithCount) => {
+    setEditing(announcement);
+    setTitle(announcement.title);
+    setBody(announcement.body);
+    setType(announcement.type);
+    setCtaLabel(announcement.ctaLabel || '');
+    setCtaUrl(announcement.ctaUrl || '');
+    setExpiresAt(toDatetimeLocalValue(announcement.expiresAt));
+    setDialogOpen(true);
+  };
+
+  const handleToggleActive = async (announcement: AnnouncementWithCount) => {
+    try {
+      const updated = await toggleAnnouncementActiveAction(announcement.id, !announcement.isActive);
+      setAnnouncements(
+        announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)),
+      );
+      toast.success(updated.isActive ? 'Announcement activated' : 'Announcement deactivated');
+    } catch (error: any) {
+      console.error('Error toggling announcement:', error);
+      toast.error(error.message || 'Failed to update announcement');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteAnnouncementAction(id);
+      setAnnouncements(announcements.filter((a) => a.id !== id));
+      toast.success('Announcement deleted');
+    } catch (error: any) {
+      console.error('Error deleting announcement:', error);
+      toast.error(error.message || 'Failed to delete announcement');
+    }
+  };
+
+  const isExpired = (announcement: AnnouncementWithCount) =>
+    announcement.expiresAt !== null && new Date(announcement.expiresAt).getTime() <= Date.now();
+
+  return (
+    <AdminListPage
+      title="Announcements"
+      description="Notify users about new functionality or ask for their input"
+      addLabel="Add Announcement"
+      dialogOpen={dialogOpen}
+      onDialogOpenChange={(open) => {
+        setDialogOpen(open);
+        if (!open) resetForm();
+      }}
+      dialogTitle={editing ? 'Edit Announcement' : 'Add Announcement'}
+      onSubmit={handleSubmit}
+      loading={loading}
+      formFields={
+        <>
+          <div>
+            <Label htmlFor="title">Title *</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g., New review workflow is live"
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="body">Body (markdown) *</Label>
+            <Textarea
+              id="body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder={'We shipped **something new**…'}
+              rows={5}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="type">Display as *</Label>
+            <Select value={type} onValueChange={(value) => setType(value as AnnouncementType)}>
+              <SelectTrigger id="type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="BANNER">Banner (top of dashboard)</SelectItem>
+                <SelectItem value="MODAL">Modal (dialog on dashboard load)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor="ctaLabel">CTA Label</Label>
+              <Input
+                id="ctaLabel"
+                value={ctaLabel}
+                onChange={(e) => setCtaLabel(e.target.value)}
+                placeholder="e.g., Fill out survey"
+              />
+            </div>
+            <div>
+              <Label htmlFor="ctaUrl">CTA URL</Label>
+              <Input
+                id="ctaUrl"
+                value={ctaUrl}
+                onChange={(e) => setCtaUrl(e.target.value)}
+                placeholder="https://forms.google.com/…"
+              />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="expiresAt">Expires At</Label>
+            <Input
+              id="expiresAt"
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+            />
+            <p className="text-xs text-gray-500 mt-1">Optional — stops showing automatically after this time</p>
+          </div>
+        </>
+      }
+    >
+      {announcements.length === 0 && (
+        <p className="text-sm text-gray-500">No announcements yet. Create one to notify users.</p>
+      )}
+      {announcements.map((announcement) => (
+        <Card key={announcement.id} className="p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="font-semibold text-lg">{announcement.title}</h3>
+                <Badge variant="outline">
+                  {announcement.type === 'BANNER' ? (
+                    <Megaphone className="h-3 w-3 mr-1" />
+                  ) : (
+                    <MessageSquare className="h-3 w-3 mr-1" />
+                  )}
+                  {announcement.type === 'BANNER' ? 'Banner' : 'Modal'}
+                </Badge>
+                {announcement.isActive && !isExpired(announcement) && <Badge>Active</Badge>}
+                {announcement.isActive && isExpired(announcement) && <Badge variant="secondary">Expired</Badge>}
+                {!announcement.isActive && <Badge variant="secondary">Inactive</Badge>}
+              </div>
+              <p className="text-sm text-gray-600 mt-1 line-clamp-2 whitespace-pre-line">{announcement.body}</p>
+              <div className="flex flex-wrap gap-3 text-xs text-gray-500 mt-2">
+                {announcement.ctaLabel && announcement.ctaUrl && <span>CTA: {announcement.ctaLabel}</span>}
+                {announcement.expiresAt && (
+                  <span>Expires: {new Date(announcement.expiresAt).toLocaleString()}</span>
+                )}
+                <span>
+                  <EyeOff className="inline h-3 w-3 mr-0.5" aria-hidden="true" />
+                  {announcement._count.dismissals} dismissed
+                </span>
+              </div>
+            </div>
+            <div className="flex shrink-0 gap-2">
+              <Button variant="outline" size="sm" onClick={() => handleToggleActive(announcement)}>
+                {announcement.isActive ? 'Deactivate' : 'Activate'}
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => handleEdit(announcement)}>
+                <Edit className="h-4 w-4" />
+              </Button>
+              <DeleteConfirmDialog
+                title="Delete Announcement"
+                description={`Are you sure you want to delete "${announcement.title}"? This action cannot be undone.`}
+                onConfirm={() => handleDelete(announcement.id)}
+              />
+            </div>
+          </div>
+        </Card>
+      ))}
+    </AdminListPage>
+  );
+}

--- a/src/app/admin/announcements/page.client.tsx
+++ b/src/app/admin/announcements/page.client.tsx
@@ -83,9 +83,9 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
 
       setDialogOpen(false);
       resetForm();
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error saving announcement:', error);
-      toast.error(error.message || 'Failed to save announcement');
+      toast.error(error instanceof Error ? error.message : 'Failed to save announcement');
     } finally {
       setLoading(false);
     }
@@ -109,9 +109,9 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
         announcements.map((a) => (a.id === updated.id ? { ...updated, _count: a._count } : a)),
       );
       toast.success(updated.isActive ? 'Announcement activated' : 'Announcement deactivated');
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error toggling announcement:', error);
-      toast.error(error.message || 'Failed to update announcement');
+      toast.error(error instanceof Error ? error.message : 'Failed to update announcement');
     }
   };
 
@@ -120,9 +120,9 @@ export default function AnnouncementsClient({ announcements: initialAnnouncement
       await deleteAnnouncementAction(id);
       setAnnouncements(announcements.filter((a) => a.id !== id));
       toast.success('Announcement deleted');
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error deleting announcement:', error);
-      toast.error(error.message || 'Failed to delete announcement');
+      toast.error(error instanceof Error ? error.message : 'Failed to delete announcement');
     }
   };
 

--- a/src/app/admin/announcements/page.tsx
+++ b/src/app/admin/announcements/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation';
+import { getCurrentUser } from '@/lib/session';
+import { listAnnouncementsWithDismissalCount } from '@/domain/announcement/announcement.repository';
+import AnnouncementsClient from './page.client';
+
+export default async function AnnouncementsPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  if (user.role !== 'ADMIN') {
+    redirect('/dashboard');
+  }
+
+  const announcements = await listAnnouncementsWithDismissalCount();
+
+  return <AnnouncementsClient announcements={announcements} />;
+}

--- a/src/app/dashboard/page.client.tsx
+++ b/src/app/dashboard/page.client.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useActiveLanguage } from '@/components/analytics-project-group';
+import { AnnouncementBanner, AnnouncementBannerData } from '@/components/announcement-banner';
+import { AnnouncementModal, AnnouncementModalData } from '@/components/announcement-modal';
 import ProjectCard from '@/components/project-card';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -13,7 +16,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Textarea } from '@/components/ui/textarea';
 import { DOCUMENT_STATUS_CONFIGS } from '@/constants/document-status';
 import { createSourceProjectAction } from '@/domain/source-project/source-project.actions';
-import { useActiveLanguage } from '@/components/analytics-project-group';
 import { capture } from '@/lib/analytics';
 import { isAdminClient } from '@/lib/permissions-client';
 import { SessionUser } from '@/lib/session';
@@ -117,6 +119,10 @@ interface DashboardClientProps {
   approvedVersions: VersionWithDetails[];
   reviewAssignments: VersionWithDetails[];
   translatingVersions: VersionWithDetails[];
+  announcements: {
+    banner: AnnouncementBannerData | null;
+    modal: AnnouncementModalData | null;
+  };
 }
 
 function getDocumentUrl(assignment: DashboardClientProps['assignments'][number]): string {
@@ -255,6 +261,7 @@ export default function DashboardClient({
   approvedVersions,
   reviewAssignments,
   translatingVersions,
+  announcements,
 }: DashboardClientProps) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState('');
@@ -341,281 +348,203 @@ export default function DashboardClient({
   });
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="border-b bg-white">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div>
-                <h1 className="text-2xl font-bold">Dashboard</h1>
-                <div className="flex items-center gap-2 mt-1">
-                  <Avatar size="sm" name={user.name || undefined}>
-                    <AvatarFallback name={user.name || undefined}>
-                      {user.name
-                        .split(' ')
-                        .map((name) => name.charAt(0))
-                        .join('')}
-                    </AvatarFallback>
-                  </Avatar>
-                  <p className="text-gray-600">Welcome back, {user.name}</p>
+    <>
+      {announcements.banner && <AnnouncementBanner announcement={announcements.banner} />}
+      {announcements.modal && <AnnouncementModal announcement={announcements.modal} />}
+      <div className="min-h-screen bg-gray-50">
+        <div className="border-b bg-white">
+          <div className="container mx-auto px-4 py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div>
+                  <h1 className="text-2xl font-bold">Dashboard</h1>
+                  <div className="flex items-center gap-2 mt-1">
+                    <Avatar size="sm" name={user.name || undefined}>
+                      <AvatarFallback name={user.name || undefined}>
+                        {user.name
+                          .split(' ')
+                          .map((name) => name.charAt(0))
+                          .join('')}
+                      </AvatarFallback>
+                    </Avatar>
+                    <p className="text-gray-600">Welcome back, {user.name}</p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <div className="mt-4">
-            <div className="relative max-w-md">
-              <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-              <Input
-                placeholder="Search projects..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9"
-              />
+            <div className="mt-4">
+              <div className="relative max-w-md">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder="Search projects..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-9"
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div className="container mx-auto px-4 py-6 space-y-8">
-        {/* Projects section */}
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold">My Projects</h2>
-            {isAdminClient(user) && (
-              <Dialog
-                open={createDialogOpen}
-                onOpenChange={(open) => {
-                  setCreateDialogOpen(open);
-                  if (open) {
-                    capture('dialog_opened', { dialog: 'create_source_project' });
-                  }
-                  if (!open) {
-                    setNewProjectName('');
-                    setNewProjectDescription('');
-                    setNewProjectIdentifier('');
-                  }
-                }}
-              >
-                <DialogTrigger asChild>
-                  <Button size="sm">
-                    <Plus className="h-4 w-4 mr-1.5" />
-                    New Project
-                  </Button>
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>Create New Project</DialogTitle>
-                  </DialogHeader>
-                  <form onSubmit={handleCreateProject} className="space-y-4">
-                    <div>
-                      <Label htmlFor="new-project-name">Project Name *</Label>
-                      <Input
-                        id="new-project-name"
-                        value={newProjectName}
-                        onChange={(e) => setNewProjectName(e.target.value)}
-                        placeholder="e.g., Exodus90, Daily Readings"
-                        required
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="new-project-description">Description</Label>
-                      <Textarea
-                        id="new-project-description"
-                        value={newProjectDescription}
-                        onChange={(e) => setNewProjectDescription(e.target.value)}
-                        placeholder="Optional description of the project"
-                        rows={3}
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="new-project-identifier">Repository Identifier</Label>
-                      <Input
-                        id="new-project-identifier"
-                        value={newProjectIdentifier}
-                        onChange={(e) => setNewProjectIdentifier(e.target.value)}
-                        placeholder="e.g., exodus90, lent2026"
-                        className="mt-1"
-                      />
-                      <p className="text-xs text-muted-foreground mt-1">
-                        GITHUB: Folder name in the content repository
-                      </p>
-                    </div>
-                    <div className="flex justify-end gap-2">
-                      <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
-                        Cancel
-                      </Button>
-                      <Button type="submit" disabled={createLoading || !newProjectName.trim()}>
-                        {createLoading ? 'Creating...' : 'Create Project'}
-                      </Button>
-                    </div>
-                  </form>
-                </DialogContent>
-              </Dialog>
-            )}
-          </div>
-          {filteredProjects.length === 0 ? (
-            <div className="text-center py-12">
-              <FolderOpen className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-              <p className="text-gray-500">{searchQuery ? 'No projects match your search' : 'No projects available'}</p>
-            </div>
-          ) : (
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {filteredProjects.map((project) => (
-                <ProjectCard key={project.id} project={project} />
-              ))}
-            </div>
-          )}
-        </section>
-
-        {/* Waiting for Deploy section - deployers only */}
-        {isAdminClient(user) && approvedVersions.length > 0 && (
+        <div className="container mx-auto px-4 py-6 space-y-8">
+          {/* Projects section */}
           <section>
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">
-                Waiting for Deploy
-                <Badge variant="secondary" size="sm" className="ml-2">
-                  {filteredApprovedVersions.length}
-                </Badge>
-              </h2>
-              {deployLanguages.length > 1 && (
-                <Select value={deployLanguageFilter} onValueChange={handleDeployLanguageFilterChange}>
-                  <SelectTrigger className="w-[180px] h-8 text-sm">
-                    <SelectValue placeholder="All languages" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All languages</SelectItem>
-                    {deployLanguages.map((lang) => (
-                      <SelectItem key={lang.id} value={lang.id}>
-                        {lang.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+              <h2 className="text-lg font-semibold">My Projects</h2>
+              {isAdminClient(user) && (
+                <Dialog
+                  open={createDialogOpen}
+                  onOpenChange={(open) => {
+                    setCreateDialogOpen(open);
+                    if (open) {
+                      capture('dialog_opened', { dialog: 'create_source_project' });
+                    }
+                    if (!open) {
+                      setNewProjectName('');
+                      setNewProjectDescription('');
+                      setNewProjectIdentifier('');
+                    }
+                  }}
+                >
+                  <DialogTrigger asChild>
+                    <Button size="sm">
+                      <Plus className="h-4 w-4 mr-1.5" />
+                      New Project
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Create New Project</DialogTitle>
+                    </DialogHeader>
+                    <form onSubmit={handleCreateProject} className="space-y-4">
+                      <div>
+                        <Label htmlFor="new-project-name">Project Name *</Label>
+                        <Input
+                          id="new-project-name"
+                          value={newProjectName}
+                          onChange={(e) => setNewProjectName(e.target.value)}
+                          placeholder="e.g., Exodus90, Daily Readings"
+                          required
+                          className="mt-1"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="new-project-description">Description</Label>
+                        <Textarea
+                          id="new-project-description"
+                          value={newProjectDescription}
+                          onChange={(e) => setNewProjectDescription(e.target.value)}
+                          placeholder="Optional description of the project"
+                          rows={3}
+                          className="mt-1"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="new-project-identifier">Repository Identifier</Label>
+                        <Input
+                          id="new-project-identifier"
+                          value={newProjectIdentifier}
+                          onChange={(e) => setNewProjectIdentifier(e.target.value)}
+                          placeholder="e.g., exodus90, lent2026"
+                          className="mt-1"
+                        />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          GITHUB: Folder name in the content repository
+                        </p>
+                      </div>
+                      <div className="flex justify-end gap-2">
+                        <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
+                          Cancel
+                        </Button>
+                        <Button type="submit" disabled={createLoading || !newProjectName.trim()}>
+                          {createLoading ? 'Creating...' : 'Create Project'}
+                        </Button>
+                      </div>
+                    </form>
+                  </DialogContent>
+                </Dialog>
               )}
             </div>
-            <Card>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className={headClass}>Document</TableHead>
-                    <TableHead className={headClass}>Project</TableHead>
-                    <TableHead className={headClass}>Language</TableHead>
-                    <TableHead className={headClass}>Translator</TableHead>
-                    <TableHead className={headClass}>Reviewer</TableHead>
-                    <TableHead className={headClass}>Status</TableHead>
-                    <TableHead className="w-[60px]" />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredApprovedVersions.map((version) => {
-                    const url = `/documents/${version.document.id}/review?version=${version.id}`;
-                    const statusConfig = DOCUMENT_STATUS_CONFIGS[version.status];
-                    return (
-                      <TableRow key={version.id} className="group cursor-pointer" onClick={() => router.push(url)}>
-                        <TableCell>
-                          <span className="font-medium text-sm">{version.document.title}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-muted-foreground">
-                            {version.document.sourceProject?.name ?? '\u2014'}
-                          </span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm font-medium">{version.language.name}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-muted-foreground">{version.user?.name ?? '\u2014'}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-muted-foreground">{version.reviewer?.name ?? '\u2014'}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span
-                            className={`inline-flex items-center gap-1.5 text-xs font-medium rounded-full px-2.5 py-0.5 ${statusConfig.color.badgeClass}`}
-                          >
-                            <span
-                              className="h-1.5 w-1.5 rounded-full"
-                              style={{ backgroundColor: statusConfig.color.hex }}
-                            />
-                            {statusConfig.name}
-                          </span>
-                        </TableCell>
-                        <TableCell>
-                          <Link href={url} onClick={(e) => e.stopPropagation()}>
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="opacity-0 group-hover:opacity-100 transition-opacity"
-                            >
-                              <ArrowRight className="h-4 w-4" />
-                            </Button>
-                          </Link>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </Card>
-          </section>
-        )}
-
-        {/* My Work section - unified view of translations, reviews, and assignments */}
-        <section>
-          <h2 className="text-lg font-semibold mb-4">
-            My Work
-            {workItems.length > 0 && (
-              <Badge variant="secondary" size="sm" className="ml-2">
-                {workItems.length}
-              </Badge>
+            {filteredProjects.length === 0 ? (
+              <div className="text-center py-12">
+                <FolderOpen className="h-8 w-8 text-gray-400 mx-auto mb-2" />
+                <p className="text-gray-500">
+                  {searchQuery ? 'No projects match your search' : 'No projects available'}
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {filteredProjects.map((project) => (
+                  <ProjectCard key={project.id} project={project} />
+                ))}
+              </div>
             )}
-          </h2>
-          {workItems.length === 0 ? (
-            <div className="text-center py-12">
-              <ClipboardList className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-              <p className="text-gray-500">No active work assigned to you</p>
-            </div>
-          ) : (
-            <Card>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className={headClass}>Document</TableHead>
-                    <TableHead className={headClass}>Project</TableHead>
-                    <TableHead className={headClass}>Language</TableHead>
-                    <TableHead className={headClass}>Translator</TableHead>
-                    <TableHead className={headClass}>Reviewer</TableHead>
-                    <TableHead className={headClass}>Status</TableHead>
-                    <TableHead className={headClass}>Deadline</TableHead>
-                    <TableHead className="w-[60px]" />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {workItems.map((item) => {
-                    const statusConfig = item.status ? DOCUMENT_STATUS_CONFIGS[item.status] : null;
+          </section>
 
-                    return (
-                      <TableRow key={item.key} className="group cursor-pointer" onClick={() => router.push(item.url)}>
-                        <TableCell>
-                          <span className="font-medium text-sm">{item.documentTitle}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-muted-foreground">{item.projectName ?? '\u2014'}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm font-medium">{item.languageName}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-muted-foreground">{item.translatorName ?? '\u2014'}</span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-muted-foreground">{item.reviewerName ?? '\u2014'}</span>
-                        </TableCell>
-                        <TableCell>
-                          {statusConfig ? (
+          {/* Waiting for Deploy section - deployers only */}
+          {isAdminClient(user) && approvedVersions.length > 0 && (
+            <section>
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-semibold">
+                  Waiting for Deploy
+                  <Badge variant="secondary" size="sm" className="ml-2">
+                    {filteredApprovedVersions.length}
+                  </Badge>
+                </h2>
+                {deployLanguages.length > 1 && (
+                  <Select value={deployLanguageFilter} onValueChange={handleDeployLanguageFilterChange}>
+                    <SelectTrigger className="w-[180px] h-8 text-sm">
+                      <SelectValue placeholder="All languages" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All languages</SelectItem>
+                      {deployLanguages.map((lang) => (
+                        <SelectItem key={lang.id} value={lang.id}>
+                          {lang.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+              <Card>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className={headClass}>Document</TableHead>
+                      <TableHead className={headClass}>Project</TableHead>
+                      <TableHead className={headClass}>Language</TableHead>
+                      <TableHead className={headClass}>Translator</TableHead>
+                      <TableHead className={headClass}>Reviewer</TableHead>
+                      <TableHead className={headClass}>Status</TableHead>
+                      <TableHead className="w-[60px]" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredApprovedVersions.map((version) => {
+                      const url = `/documents/${version.document.id}/review?version=${version.id}`;
+                      const statusConfig = DOCUMENT_STATUS_CONFIGS[version.status];
+                      return (
+                        <TableRow key={version.id} className="group cursor-pointer" onClick={() => router.push(url)}>
+                          <TableCell>
+                            <span className="font-medium text-sm">{version.document.title}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">
+                              {version.document.sourceProject?.name ?? '\u2014'}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm font-medium">{version.language.name}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">{version.user?.name ?? '\u2014'}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">{version.reviewer?.name ?? '\u2014'}</span>
+                          </TableCell>
+                          <TableCell>
                             <span
                               className={`inline-flex items-center gap-1.5 text-xs font-medium rounded-full px-2.5 py-0.5 ${statusConfig.color.badgeClass}`}
                             >
@@ -625,45 +554,129 @@ export default function DashboardClient({
                               />
                               {statusConfig.name}
                             </span>
-                          ) : (
-                            <span className="inline-flex items-center gap-1.5 text-xs font-medium rounded-full px-2.5 py-0.5 border border-gray-200 bg-gray-50 text-gray-500">
-                              Not started
-                            </span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {item.deadline ? (
-                            <span className="text-sm text-muted-foreground">
-                              {shortDateFormatter.format(new Date(item.deadline))}
-                            </span>
-                          ) : (
-                            <span className="text-sm text-muted-foreground">{'\u2014'}</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <Link href={item.url} onClick={(e) => e.stopPropagation()}>
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="opacity-0 group-hover:opacity-100 transition-opacity"
-                            >
-                              {item.role === 'Reviewer' ? (
-                                <Eye className="h-4 w-4" />
-                              ) : (
+                          </TableCell>
+                          <TableCell>
+                            <Link href={url} onClick={(e) => e.stopPropagation()}>
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                className="opacity-0 group-hover:opacity-100 transition-opacity"
+                              >
                                 <ArrowRight className="h-4 w-4" />
-                              )}
-                            </Button>
-                          </Link>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </Card>
+                              </Button>
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </Card>
+            </section>
           )}
-        </section>
+
+          {/* My Work section - unified view of translations, reviews, and assignments */}
+          <section>
+            <h2 className="text-lg font-semibold mb-4">
+              My Work
+              {workItems.length > 0 && (
+                <Badge variant="secondary" size="sm" className="ml-2">
+                  {workItems.length}
+                </Badge>
+              )}
+            </h2>
+            {workItems.length === 0 ? (
+              <div className="text-center py-12">
+                <ClipboardList className="h-8 w-8 text-gray-400 mx-auto mb-2" />
+                <p className="text-gray-500">No active work assigned to you</p>
+              </div>
+            ) : (
+              <Card>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className={headClass}>Document</TableHead>
+                      <TableHead className={headClass}>Project</TableHead>
+                      <TableHead className={headClass}>Language</TableHead>
+                      <TableHead className={headClass}>Translator</TableHead>
+                      <TableHead className={headClass}>Reviewer</TableHead>
+                      <TableHead className={headClass}>Status</TableHead>
+                      <TableHead className={headClass}>Deadline</TableHead>
+                      <TableHead className="w-[60px]" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {workItems.map((item) => {
+                      const statusConfig = item.status ? DOCUMENT_STATUS_CONFIGS[item.status] : null;
+
+                      return (
+                        <TableRow key={item.key} className="group cursor-pointer" onClick={() => router.push(item.url)}>
+                          <TableCell>
+                            <span className="font-medium text-sm">{item.documentTitle}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">{item.projectName ?? '\u2014'}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm font-medium">{item.languageName}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">{item.translatorName ?? '\u2014'}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">{item.reviewerName ?? '\u2014'}</span>
+                          </TableCell>
+                          <TableCell>
+                            {statusConfig ? (
+                              <span
+                                className={`inline-flex items-center gap-1.5 text-xs font-medium rounded-full px-2.5 py-0.5 ${statusConfig.color.badgeClass}`}
+                              >
+                                <span
+                                  className="h-1.5 w-1.5 rounded-full"
+                                  style={{ backgroundColor: statusConfig.color.hex }}
+                                />
+                                {statusConfig.name}
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center gap-1.5 text-xs font-medium rounded-full px-2.5 py-0.5 border border-gray-200 bg-gray-50 text-gray-500">
+                                Not started
+                              </span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {item.deadline ? (
+                              <span className="text-sm text-muted-foreground">
+                                {shortDateFormatter.format(new Date(item.deadline))}
+                              </span>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">{'\u2014'}</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Link href={item.url} onClick={(e) => e.stopPropagation()}>
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                className="opacity-0 group-hover:opacity-100 transition-opacity"
+                              >
+                                {item.role === 'Reviewer' ? (
+                                  <Eye className="h-4 w-4" />
+                                ) : (
+                                  <ArrowRight className="h-4 w-4" />
+                                )}
+                              </Button>
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </Card>
+            )}
+          </section>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,5 @@
 'use server';
 
-import { AnnouncementBanner } from '@/components/announcement-banner';
-import { AnnouncementModal } from '@/components/announcement-modal';
 import { getVisibleAnnouncementsAction } from '@/domain/announcement/announcement.actions';
 import { getAssignedDocumentsForUserAction } from '@/domain/document-assignment/document-assignment.actions';
 import {
@@ -38,17 +36,14 @@ export default async function DashboardPage() {
     ]);
 
   return (
-    <>
-      {announcements.banner && <AnnouncementBanner announcement={announcements.banner} />}
-      {announcements.modal && <AnnouncementModal announcement={announcements.modal} />}
-      <DashboardClient
-        user={user}
-        projects={projects}
-        assignments={assignments}
-        approvedVersions={approvedVersions}
-        reviewAssignments={reviewAssignments}
-        translatingVersions={translatingVersions}
-      />
-    </>
+    <DashboardClient
+      user={user}
+      projects={projects}
+      assignments={assignments}
+      approvedVersions={approvedVersions}
+      reviewAssignments={reviewAssignments}
+      translatingVersions={translatingVersions}
+      announcements={announcements}
+    />
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 'use server';
 
+import { AnnouncementBanner } from '@/components/announcement-banner';
+import { getVisibleAnnouncementsAction } from '@/domain/announcement/announcement.actions';
 import { getAssignedDocumentsForUserAction } from '@/domain/document-assignment/document-assignment.actions';
 import {
   getApprovedVersionsAction,
@@ -24,22 +26,27 @@ export default async function DashboardPage() {
     redirect('/onboarding/profile');
   }
 
-  const [projects, assignments, approvedVersions, reviewAssignments, translatingVersions] = await Promise.all([
-    getSourceProjectsForUserAction(),
-    getAssignedDocumentsForUserAction(),
-    getApprovedVersionsAction(),
-    getVersionsForReviewByUserAction(),
-    getVersionsTranslatingByUserAction(),
-  ]);
+  const [projects, assignments, approvedVersions, reviewAssignments, translatingVersions, announcements] =
+    await Promise.all([
+      getSourceProjectsForUserAction(),
+      getAssignedDocumentsForUserAction(),
+      getApprovedVersionsAction(),
+      getVersionsForReviewByUserAction(),
+      getVersionsTranslatingByUserAction(),
+      getVisibleAnnouncementsAction(),
+    ]);
 
   return (
-    <DashboardClient
-      user={user}
-      projects={projects}
-      assignments={assignments}
-      approvedVersions={approvedVersions}
-      reviewAssignments={reviewAssignments}
-      translatingVersions={translatingVersions}
-    />
+    <>
+      {announcements.banner && <AnnouncementBanner announcement={announcements.banner} />}
+      <DashboardClient
+        user={user}
+        projects={projects}
+        assignments={assignments}
+        approvedVersions={approvedVersions}
+        reviewAssignments={reviewAssignments}
+        translatingVersions={translatingVersions}
+      />
+    </>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use server';
 
 import { AnnouncementBanner } from '@/components/announcement-banner';
+import { AnnouncementModal } from '@/components/announcement-modal';
 import { getVisibleAnnouncementsAction } from '@/domain/announcement/announcement.actions';
 import { getAssignedDocumentsForUserAction } from '@/domain/document-assignment/document-assignment.actions';
 import {
@@ -39,6 +40,7 @@ export default async function DashboardPage() {
   return (
     <>
       {announcements.banner && <AnnouncementBanner announcement={announcements.banner} />}
+      {announcements.modal && <AnnouncementModal announcement={announcements.modal} />}
       <DashboardClient
         user={user}
         projects={projects}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,7 +51,7 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  --primary: oklch(0.55 0.11 190);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
@@ -62,7 +62,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.7 0.09 190);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -70,12 +70,12 @@
   --chart-5: oklch(0.769 0.188 70.08);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary: oklch(0.55 0.11 190);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: oklch(0.7 0.09 190);
 }
 
 .dark {
@@ -85,8 +85,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.7 0.1 190);
+  --primary-foreground: oklch(0.145 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -96,7 +96,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.55 0.11 190);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -104,12 +104,12 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.7 0.1 190);
+  --sidebar-primary-foreground: oklch(0.145 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.55 0.11 190);
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,7 +51,7 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.55 0.11 190);
+  --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
@@ -62,7 +62,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.7 0.09 190);
+  --ring: oklch(0.708 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -70,12 +70,12 @@
   --chart-5: oklch(0.769 0.188 70.08);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.55 0.11 190);
+  --sidebar-primary: oklch(0.205 0 0);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.7 0.09 190);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
@@ -85,8 +85,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.7 0.1 190);
-  --primary-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -96,7 +96,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.55 0.11 190);
+  --ring: oklch(0.556 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -104,12 +104,12 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.7 0.1 190);
-  --sidebar-primary-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.55 0.11 190);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -1,17 +1,16 @@
 'use client';
 
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
-import { AnnouncementMarkdown } from '@/components/announcement-markdown';
-import { Button } from '@/components/ui/button';
 import { capture } from '@/lib/analytics';
-import { ExternalLink, Megaphone, X } from 'lucide-react';
+import { Megaphone, X } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
+// Banners are one-liners: only the title is shown. Longer content
+// (markdown body) belongs in a MODAL announcement.
 export interface AnnouncementBannerData {
   id: string;
   title: string;
-  body: string;
   ctaLabel: string | null;
   ctaUrl: string | null;
 }
@@ -46,39 +45,34 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
   };
 
   return (
-    <div className="border-b border-primary/20 bg-primary/5">
-      <div className="container mx-auto px-4 py-3">
-        <div className="flex items-start gap-3">
-          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold text-foreground">{announcement.title}</p>
-            <div className="text-muted-foreground">
-              <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
-            </div>
-          </div>
+    <div className="bg-zinc-900">
+      <div className="container mx-auto px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white/10">
+            <Megaphone className="h-3.5 w-3.5 text-white" aria-hidden="true" />
+          </span>
+          <p className="min-w-0 flex-1 truncate text-sm font-medium text-white">{announcement.title}</p>
           {announcement.ctaLabel && announcement.ctaUrl && (
-            <Button asChild size="sm" className="shrink-0 self-center">
-              <Link
-                href={announcement.ctaUrl}
-                target="_blank"
-                onClick={() =>
-                  capture('announcement_cta_clicked', {
-                    announcement_id: announcement.id,
-                    announcement_title: announcement.title,
-                    display: 'banner',
-                  })
-                }
-              >
-                {announcement.ctaLabel}
-                <ExternalLink className="ml-2 h-3.5 w-3.5" />
-              </Link>
-            </Button>
+            <Link
+              href={announcement.ctaUrl}
+              target="_blank"
+              onClick={() =>
+                capture('announcement_cta_clicked', {
+                  announcement_id: announcement.id,
+                  announcement_title: announcement.title,
+                  display: 'banner',
+                })
+              }
+              className="shrink-0 text-sm font-semibold text-white hover:underline"
+            >
+              {announcement.ctaLabel}
+            </Link>
           )}
           <button
             type="button"
             onClick={handleDismiss}
             aria-label="Dismiss announcement"
-            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
+            className="shrink-0 rounded-md p-1 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
           >
             <X className="h-4 w-4" />
           </button>

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
-import { Megaphone, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ExternalLink, Megaphone, X } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -10,6 +12,8 @@ export interface AnnouncementBannerData {
   id: string;
   title: string;
   body: string;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
 }
 
 interface AnnouncementBannerProps {
@@ -39,6 +43,14 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
             </div>
           </div>
+          {announcement.ctaLabel && announcement.ctaUrl && (
+            <Button asChild size="sm" className="shrink-0 self-center">
+              <Link href={announcement.ctaUrl} target="_blank">
+                {announcement.ctaLabel}
+                <ExternalLink className="ml-2 h-3.5 w-3.5" />
+              </Link>
+            </Button>
+          )}
           <button
             type="button"
             onClick={handleDismiss}

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Megaphone } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export interface AnnouncementBannerData {
+  id: string;
+  title: string;
+  body: string;
+}
+
+interface AnnouncementBannerProps {
+  announcement: AnnouncementBannerData;
+}
+
+export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
+  return (
+    <div className="border-b border-blue-200 bg-blue-50">
+      <div className="container mx-auto px-4 py-3">
+        <div className="flex items-start gap-3">
+          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-blue-900">{announcement.title}</p>
+            <div className="prose prose-sm max-w-none text-sm text-blue-900/90">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Megaphone } from 'lucide-react';
+import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
+import { Megaphone, X } from 'lucide-react';
+import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -15,6 +17,17 @@ interface AnnouncementBannerProps {
 }
 
 export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    void dismissAnnouncementAction(announcement.id);
+  };
+
   return (
     <div className="border-b border-blue-200 bg-blue-50">
       <div className="container mx-auto px-4 py-3">
@@ -26,6 +39,14 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
             </div>
           </div>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss announcement"
+            className="rounded-md p-1 text-blue-600 transition-colors hover:bg-blue-100 hover:text-blue-900"
+          >
+            <X className="h-4 w-4" />
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
+import { AnnouncementMarkdown } from '@/components/announcement-markdown';
 import { Button } from '@/components/ui/button';
 import { capture } from '@/lib/analytics';
 import { ExternalLink, Megaphone, X } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
 export interface AnnouncementBannerData {
   id: string;
@@ -47,14 +46,14 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
   };
 
   return (
-    <div className="border-b border-blue-200 bg-blue-50">
+    <div className="border-b bg-white">
       <div className="container mx-auto px-4 py-3">
         <div className="flex items-start gap-3">
-          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" aria-hidden="true" />
+          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-gray-500" aria-hidden="true" />
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold text-blue-900">{announcement.title}</p>
-            <div className="prose prose-sm max-w-none text-sm text-blue-900/90">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
+            <p className="text-sm font-semibold text-gray-900">{announcement.title}</p>
+            <div className="text-gray-600">
+              <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
             </div>
           </div>
           {announcement.ctaLabel && announcement.ctaUrl && (
@@ -79,7 +78,7 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
             type="button"
             onClick={handleDismiss}
             aria-label="Dismiss announcement"
-            className="rounded-md p-1 text-blue-600 transition-colors hover:bg-blue-100 hover:text-blue-900"
+            className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
           >
             <X className="h-4 w-4" />
           </button>

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -2,9 +2,10 @@
 
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
 import { Button } from '@/components/ui/button';
+import { capture } from '@/lib/analytics';
 import { ExternalLink, Megaphone, X } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -23,12 +24,25 @@ interface AnnouncementBannerProps {
 export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
   const [dismissed, setDismissed] = useState(false);
 
+  useEffect(() => {
+    capture('announcement_shown', {
+      announcement_id: announcement.id,
+      announcement_title: announcement.title,
+      display: 'banner',
+    });
+  }, [announcement.id, announcement.title]);
+
   if (dismissed) {
     return null;
   }
 
   const handleDismiss = () => {
     setDismissed(true);
+    capture('announcement_dismissed', {
+      announcement_id: announcement.id,
+      announcement_title: announcement.title,
+      display: 'banner',
+    });
     void dismissAnnouncementAction(announcement.id);
   };
 
@@ -45,7 +59,17 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
           </div>
           {announcement.ctaLabel && announcement.ctaUrl && (
             <Button asChild size="sm" className="shrink-0 self-center">
-              <Link href={announcement.ctaUrl} target="_blank">
+              <Link
+                href={announcement.ctaUrl}
+                target="_blank"
+                onClick={() =>
+                  capture('announcement_cta_clicked', {
+                    announcement_id: announcement.id,
+                    announcement_title: announcement.title,
+                    display: 'banner',
+                  })
+                }
+              >
                 {announcement.ctaLabel}
                 <ExternalLink className="ml-2 h-3.5 w-3.5" />
               </Link>

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -46,13 +46,13 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
   };
 
   return (
-    <div className="border-b bg-white">
+    <div className="border-b border-primary/20 bg-primary/5">
       <div className="container mx-auto px-4 py-3">
         <div className="flex items-start gap-3">
-          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-gray-500" aria-hidden="true" />
+          <Megaphone className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold text-gray-900">{announcement.title}</p>
-            <div className="text-gray-600">
+            <p className="text-sm font-semibold text-foreground">{announcement.title}</p>
+            <div className="text-muted-foreground">
               <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
             </div>
           </div>
@@ -78,7 +78,7 @@ export function AnnouncementBanner({ announcement }: AnnouncementBannerProps) {
             type="button"
             onClick={handleDismiss}
             aria-label="Dismiss announcement"
-            className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-foreground"
           >
             <X className="h-4 w-4" />
           </button>

--- a/src/components/announcement-markdown.tsx
+++ b/src/components/announcement-markdown.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// Compact markdown styling for announcement surfaces. Deliberately does NOT
+// use `.prose` (globals.css): those rules are unlayered so they beat Tailwind
+// utilities, and their document-scale spacing (leading-7, my-3) balloons a
+// slim banner or dialog.
+const MARKDOWN_CLASSES = [
+  'text-sm leading-snug',
+  '[&_p]:my-1',
+  '[&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5',
+  '[&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5',
+  '[&_li]:my-0.5 [&_li]:leading-snug',
+  '[&_a]:font-medium [&_a]:underline hover:[&_a]:opacity-80',
+  '[&_strong]:font-semibold',
+  '[&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs',
+].join(' ');
+
+export function AnnouncementMarkdown({ children }: { children: string }) {
+  return (
+    <div className={MARKDOWN_CLASSES}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+    </div>
+  );
+}

--- a/src/components/announcement-modal.tsx
+++ b/src/components/announcement-modal.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react';
 export interface AnnouncementModalData {
   id: string;
   title: string;
-  body: string;
+  body: string | null;
   ctaLabel: string | null;
   ctaUrl: string | null;
 }
@@ -52,7 +52,7 @@ export function AnnouncementModal({ announcement }: AnnouncementModalProps) {
         <DialogHeader>
           <DialogTitle>{announcement.title}</DialogTitle>
         </DialogHeader>
-        <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
+        {announcement.body && <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>}
         {announcement.ctaLabel && announcement.ctaUrl && (
           <DialogFooter>
             <Button asChild>

--- a/src/components/announcement-modal.tsx
+++ b/src/components/announcement-modal.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
+import { AnnouncementMarkdown } from '@/components/announcement-markdown';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { capture } from '@/lib/analytics';
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
 export interface AnnouncementModalData {
   id: string;
@@ -53,9 +52,7 @@ export function AnnouncementModal({ announcement }: AnnouncementModalProps) {
         <DialogHeader>
           <DialogTitle>{announcement.title}</DialogTitle>
         </DialogHeader>
-        <div className="prose prose-sm max-w-none text-sm">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
-        </div>
+        <AnnouncementMarkdown>{announcement.body}</AnnouncementMarkdown>
         {announcement.ctaLabel && announcement.ctaUrl && (
           <DialogFooter>
             <Button asChild>

--- a/src/components/announcement-modal.tsx
+++ b/src/components/announcement-modal.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export interface AnnouncementModalData {
+  id: string;
+  title: string;
+  body: string;
+}
+
+interface AnnouncementModalProps {
+  announcement: AnnouncementModalData;
+}
+
+export function AnnouncementModal({ announcement }: AnnouncementModalProps) {
+  const [open, setOpen] = useState(true);
+
+  // Every close path (X button, ESC, outside click) goes through
+  // onOpenChange, so any close permanently dismisses.
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      void dismissAnnouncementAction(announcement.id);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{announcement.title}</DialogTitle>
+        </DialogHeader>
+        <div className="prose prose-sm max-w-none text-sm">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/announcement-modal.tsx
+++ b/src/components/announcement-modal.tsx
@@ -3,9 +3,10 @@
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { capture } from '@/lib/analytics';
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -24,11 +25,24 @@ interface AnnouncementModalProps {
 export function AnnouncementModal({ announcement }: AnnouncementModalProps) {
   const [open, setOpen] = useState(true);
 
+  useEffect(() => {
+    capture('announcement_shown', {
+      announcement_id: announcement.id,
+      announcement_title: announcement.title,
+      display: 'modal',
+    });
+  }, [announcement.id, announcement.title]);
+
   // Every close path (X button, ESC, outside click) goes through
   // onOpenChange, so any close permanently dismisses.
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (!nextOpen) {
+      capture('announcement_dismissed', {
+        announcement_id: announcement.id,
+        announcement_title: announcement.title,
+        display: 'modal',
+      });
       void dismissAnnouncementAction(announcement.id);
     }
   };
@@ -45,7 +59,17 @@ export function AnnouncementModal({ announcement }: AnnouncementModalProps) {
         {announcement.ctaLabel && announcement.ctaUrl && (
           <DialogFooter>
             <Button asChild>
-              <Link href={announcement.ctaUrl} target="_blank">
+              <Link
+                href={announcement.ctaUrl}
+                target="_blank"
+                onClick={() =>
+                  capture('announcement_cta_clicked', {
+                    announcement_id: announcement.id,
+                    announcement_title: announcement.title,
+                    display: 'modal',
+                  })
+                }
+              >
                 {announcement.ctaLabel}
                 <ExternalLink className="ml-2 h-4 w-4" />
               </Link>

--- a/src/components/announcement-modal.tsx
+++ b/src/components/announcement-modal.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { dismissAnnouncementAction } from '@/domain/announcement/announcement.actions';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ExternalLink } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -10,6 +13,8 @@ export interface AnnouncementModalData {
   id: string;
   title: string;
   body: string;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
 }
 
 interface AnnouncementModalProps {
@@ -37,6 +42,16 @@ export function AnnouncementModal({ announcement }: AnnouncementModalProps) {
         <div className="prose prose-sm max-w-none text-sm">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{announcement.body}</ReactMarkdown>
         </div>
+        {announcement.ctaLabel && announcement.ctaUrl && (
+          <DialogFooter>
+            <Button asChild>
+              <Link href={announcement.ctaUrl} target="_blank">
+                {announcement.ctaLabel}
+                <ExternalLink className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -56,6 +56,9 @@ export function Navigation({ user }: NavigationProps) {
                   <Link href="/admin/users" className="text-sm text-gray-600 hover:text-gray-900">
                     Users
                   </Link>
+                  <Link href="/admin/announcements" className="text-sm text-gray-600 hover:text-gray-900">
+                    Announcements
+                  </Link>
                   <Link href="/settings/language-instructions" className="text-sm text-gray-600 hover:text-gray-900">
                     Language Instructions
                   </Link>

--- a/src/domain/announcement/announcement.actions.ts
+++ b/src/domain/announcement/announcement.actions.ts
@@ -3,10 +3,16 @@
 import { z } from 'zod';
 import { authorize } from '@/lib/authorize';
 import {
+  createAnnouncement,
+  deleteAnnouncement,
   dismissAnnouncement,
   listActiveAnnouncements,
+  listAnnouncementsWithDismissalCount,
   listDismissedAnnouncementIds,
+  setAnnouncementActive,
+  updateAnnouncement,
 } from './announcement.repository';
+import { announcementInputSchema } from './announcement.types';
 import { selectVisibleAnnouncements } from './announcement.visibility';
 
 export async function getVisibleAnnouncementsAction() {
@@ -25,4 +31,35 @@ export async function dismissAnnouncementAction(announcementId: unknown) {
   const parsed = z.string().uuid().parse(announcementId);
   await dismissAnnouncement(user.id, parsed);
   return { success: true };
+}
+
+export async function listAnnouncementsAction() {
+  await authorize('admin');
+  return listAnnouncementsWithDismissalCount();
+}
+
+export async function createAnnouncementAction(input: unknown) {
+  await authorize('admin');
+  const parsed = announcementInputSchema.parse(input);
+  return createAnnouncement(parsed);
+}
+
+export async function updateAnnouncementAction(id: string, input: unknown) {
+  await authorize('admin');
+  const parsedId = z.string().uuid().parse(id);
+  const parsed = announcementInputSchema.parse(input);
+  return updateAnnouncement(parsedId, parsed);
+}
+
+export async function deleteAnnouncementAction(id: string) {
+  await authorize('admin');
+  const parsedId = z.string().uuid().parse(id);
+  return deleteAnnouncement(parsedId);
+}
+
+export async function toggleAnnouncementActiveAction(id: string, isActive: boolean) {
+  await authorize('admin');
+  const parsedId = z.string().uuid().parse(id);
+  const parsedActive = z.boolean().parse(isActive);
+  return setAnnouncementActive(parsedId, parsedActive);
 }

--- a/src/domain/announcement/announcement.actions.ts
+++ b/src/domain/announcement/announcement.actions.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { authorize } from '@/lib/authorize';
+import { listActiveAnnouncements, listDismissedAnnouncementIds } from './announcement.repository';
+import { selectVisibleAnnouncements } from './announcement.visibility';
+
+export async function getVisibleAnnouncementsAction() {
+  const { user } = await authorize('authenticated');
+
+  const [announcements, dismissedIds] = await Promise.all([
+    listActiveAnnouncements(),
+    listDismissedAnnouncementIds(user.id),
+  ]);
+
+  return selectVisibleAnnouncements(announcements, new Set(dismissedIds), new Date());
+}

--- a/src/domain/announcement/announcement.actions.ts
+++ b/src/domain/announcement/announcement.actions.ts
@@ -1,7 +1,12 @@
 'use server';
 
+import { z } from 'zod';
 import { authorize } from '@/lib/authorize';
-import { listActiveAnnouncements, listDismissedAnnouncementIds } from './announcement.repository';
+import {
+  dismissAnnouncement,
+  listActiveAnnouncements,
+  listDismissedAnnouncementIds,
+} from './announcement.repository';
 import { selectVisibleAnnouncements } from './announcement.visibility';
 
 export async function getVisibleAnnouncementsAction() {
@@ -13,4 +18,11 @@ export async function getVisibleAnnouncementsAction() {
   ]);
 
   return selectVisibleAnnouncements(announcements, new Set(dismissedIds), new Date());
+}
+
+export async function dismissAnnouncementAction(announcementId: unknown) {
+  const { user } = await authorize('authenticated');
+  const parsed = z.string().uuid().parse(announcementId);
+  await dismissAnnouncement(user.id, parsed);
+  return { success: true };
 }

--- a/src/domain/announcement/announcement.repository.ts
+++ b/src/domain/announcement/announcement.repository.ts
@@ -7,6 +7,15 @@ export async function listActiveAnnouncements() {
   });
 }
 
+export async function dismissAnnouncement(userId: string, announcementId: string) {
+  return prisma.announcementDismissal.upsert({
+    where: { announcementId_userId: { announcementId, userId } },
+    create: { announcementId, userId },
+    update: {},
+    select: { id: true },
+  });
+}
+
 export async function listDismissedAnnouncementIds(userId: string): Promise<string[]> {
   const dismissals = await prisma.announcementDismissal.findMany({
     where: { userId },

--- a/src/domain/announcement/announcement.repository.ts
+++ b/src/domain/announcement/announcement.repository.ts
@@ -1,4 +1,28 @@
 import prisma from '@/lib/db';
+import type { AnnouncementInput } from './announcement.types';
+
+export async function listAnnouncementsWithDismissalCount() {
+  return prisma.announcement.findMany({
+    include: { _count: { select: { dismissals: true } } },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function createAnnouncement(data: AnnouncementInput) {
+  return prisma.announcement.create({ data });
+}
+
+export async function updateAnnouncement(id: string, data: AnnouncementInput) {
+  return prisma.announcement.update({ where: { id }, data });
+}
+
+export async function deleteAnnouncement(id: string) {
+  return prisma.announcement.delete({ where: { id }, select: { id: true } });
+}
+
+export async function setAnnouncementActive(id: string, isActive: boolean) {
+  return prisma.announcement.update({ where: { id }, data: { isActive } });
+}
 
 export async function listActiveAnnouncements() {
   return prisma.announcement.findMany({

--- a/src/domain/announcement/announcement.repository.ts
+++ b/src/domain/announcement/announcement.repository.ts
@@ -1,0 +1,16 @@
+import prisma from '@/lib/db';
+
+export async function listActiveAnnouncements() {
+  return prisma.announcement.findMany({
+    where: { isActive: true },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function listDismissedAnnouncementIds(userId: string): Promise<string[]> {
+  const dismissals = await prisma.announcementDismissal.findMany({
+    where: { userId },
+    select: { announcementId: true },
+  });
+  return dismissals.map((d) => d.announcementId);
+}

--- a/src/domain/announcement/announcement.types.test.ts
+++ b/src/domain/announcement/announcement.types.test.ts
@@ -26,9 +26,27 @@ describe('announcementInputSchema', () => {
     assert.strictEqual(parsed.expiresAt, null);
   });
 
-  it('accepts MODAL type', () => {
+  it('accepts MODAL type with a body', () => {
     const parsed = announcementInputSchema.parse(validInput({ type: 'MODAL' }));
     assert.strictEqual(parsed.type, 'MODAL');
+  });
+
+  it('accepts a BANNER without a body (one-liner)', () => {
+    const parsed = announcementInputSchema.parse(validInput({ body: null }));
+    assert.strictEqual(parsed.body, null);
+  });
+
+  it('treats an empty-string body as absent', () => {
+    const parsed = announcementInputSchema.parse(validInput({ body: '' }));
+    assert.strictEqual(parsed.body, null);
+  });
+
+  it('rejects a MODAL without a body', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ type: 'MODAL', body: null })));
+  });
+
+  it('rejects a MODAL with an empty body', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ type: 'MODAL', body: '' })));
   });
 
   it('rejects an unknown type', () => {
@@ -41,9 +59,6 @@ describe('announcementInputSchema', () => {
     );
   });
 
-  it('rejects an empty body', () => {
-    assert.throws(() => announcementInputSchema.parse(validInput({ body: '' })));
-  });
 
   it('accepts CTA label and URL together', () => {
     const parsed = announcementInputSchema.parse(

--- a/src/domain/announcement/announcement.types.test.ts
+++ b/src/domain/announcement/announcement.types.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { announcementInputSchema } from './announcement.types';
+
+// ─── Test fixtures ───────────────────────────────────────────
+
+function validInput(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'New feature released',
+    body: 'We shipped **something great**.',
+    type: 'BANNER',
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────
+
+describe('announcementInputSchema', () => {
+  it('accepts a minimal valid input and applies defaults', () => {
+    const parsed = announcementInputSchema.parse(validInput());
+    assert.strictEqual(parsed.title, 'New feature released');
+    assert.strictEqual(parsed.type, 'BANNER');
+    assert.strictEqual(parsed.ctaLabel, null);
+    assert.strictEqual(parsed.ctaUrl, null);
+    assert.strictEqual(parsed.isActive, false);
+    assert.strictEqual(parsed.expiresAt, null);
+  });
+
+  it('accepts MODAL type', () => {
+    const parsed = announcementInputSchema.parse(validInput({ type: 'MODAL' }));
+    assert.strictEqual(parsed.type, 'MODAL');
+  });
+
+  it('rejects an unknown type', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ type: 'TOAST' })));
+  });
+
+  it('rejects a missing title', () => {
+    const { title: _title, ...rest } = validInput();
+    assert.throws(() => announcementInputSchema.parse(rest));
+  });
+
+  it('rejects an empty body', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ body: '' })));
+  });
+
+  it('accepts CTA label and URL together', () => {
+    const parsed = announcementInputSchema.parse(
+      validInput({ ctaLabel: 'Fill out survey', ctaUrl: 'https://forms.example.com/abc' }),
+    );
+    assert.strictEqual(parsed.ctaLabel, 'Fill out survey');
+    assert.strictEqual(parsed.ctaUrl, 'https://forms.example.com/abc');
+  });
+
+  it('rejects a CTA label without a URL', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ ctaLabel: 'Fill out survey' })));
+  });
+
+  it('rejects a CTA URL without a label', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ ctaUrl: 'https://forms.example.com/abc' })));
+  });
+
+  it('rejects an invalid CTA URL', () => {
+    assert.throws(() =>
+      announcementInputSchema.parse(validInput({ ctaLabel: 'Survey', ctaUrl: 'not-a-url' })),
+    );
+  });
+
+  it('treats empty-string CTA fields as absent', () => {
+    const parsed = announcementInputSchema.parse(validInput({ ctaLabel: '', ctaUrl: '' }));
+    assert.strictEqual(parsed.ctaLabel, null);
+    assert.strictEqual(parsed.ctaUrl, null);
+  });
+
+  it('coerces an ISO string expiry to a Date', () => {
+    const parsed = announcementInputSchema.parse(validInput({ expiresAt: '2026-08-01T00:00:00.000Z' }));
+    assert.ok(parsed.expiresAt instanceof Date);
+    assert.strictEqual(parsed.expiresAt.toISOString(), '2026-08-01T00:00:00.000Z');
+  });
+
+  it('keeps a null expiry as null (not the epoch)', () => {
+    const parsed = announcementInputSchema.parse(validInput({ expiresAt: null }));
+    assert.strictEqual(parsed.expiresAt, null);
+  });
+
+  it('treats an empty-string expiry as null', () => {
+    const parsed = announcementInputSchema.parse(validInput({ expiresAt: '' }));
+    assert.strictEqual(parsed.expiresAt, null);
+  });
+
+  it('rejects an unparseable expiry', () => {
+    assert.throws(() => announcementInputSchema.parse(validInput({ expiresAt: 'not-a-date' })));
+  });
+
+  it('accepts isActive true', () => {
+    const parsed = announcementInputSchema.parse(validInput({ isActive: true }));
+    assert.strictEqual(parsed.isActive, true);
+  });
+});

--- a/src/domain/announcement/announcement.types.test.ts
+++ b/src/domain/announcement/announcement.types.test.ts
@@ -36,8 +36,9 @@ describe('announcementInputSchema', () => {
   });
 
   it('rejects a missing title', () => {
-    const { title: _title, ...rest } = validInput();
-    assert.throws(() => announcementInputSchema.parse(rest));
+    assert.throws(() =>
+      announcementInputSchema.parse({ body: 'We shipped something.', type: 'BANNER' }),
+    );
   });
 
   it('rejects an empty body', () => {

--- a/src/domain/announcement/announcement.types.ts
+++ b/src/domain/announcement/announcement.types.ts
@@ -16,7 +16,8 @@ const nullableTrimmedString = z.preprocess(
 export const announcementInputSchema = z
   .object({
     title: z.string().min(1, 'Title is required'),
-    body: z.string().min(1, 'Body is required'),
+    // Banners are one-liners showing just the title; only modals render a body.
+    body: nullableTrimmedString,
     type: z.enum(['BANNER', 'MODAL']),
     ctaLabel: nullableTrimmedString,
     ctaUrl: z.preprocess(
@@ -29,6 +30,10 @@ export const announcementInputSchema = z
   .refine((data) => (data.ctaLabel === null) === (data.ctaUrl === null), {
     message: 'CTA label and URL must be provided together',
     path: ['ctaLabel'],
+  })
+  .refine((data) => data.type !== 'MODAL' || data.body !== null, {
+    message: 'Body is required for modal announcements',
+    path: ['body'],
   });
 
 export type AnnouncementInput = z.infer<typeof announcementInputSchema>;

--- a/src/domain/announcement/announcement.types.ts
+++ b/src/domain/announcement/announcement.types.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+// z.coerce.date() would turn null into new Date(0), so expiry is
+// normalized via preprocess: empty/absent values become null, anything
+// else must parse to a valid date.
+const expiresAtSchema = z.preprocess(
+  (value) => (value === null || value === undefined || value === '' ? null : new Date(value as string | number | Date)),
+  z.date().nullable(),
+);
+
+const nullableTrimmedString = z.preprocess(
+  (value) => (typeof value === 'string' && value.trim() === '' ? null : value),
+  z.string().min(1).nullable().optional().default(null),
+);
+
+export const announcementInputSchema = z
+  .object({
+    title: z.string().min(1, 'Title is required'),
+    body: z.string().min(1, 'Body is required'),
+    type: z.enum(['BANNER', 'MODAL']),
+    ctaLabel: nullableTrimmedString,
+    ctaUrl: z.preprocess(
+      (value) => (typeof value === 'string' && value.trim() === '' ? null : value),
+      z.string().url('CTA URL must be a valid URL').nullable().optional().default(null),
+    ),
+    isActive: z.boolean().optional().default(false),
+    expiresAt: expiresAtSchema,
+  })
+  .refine((data) => (data.ctaLabel === null) === (data.ctaUrl === null), {
+    message: 'CTA label and URL must be provided together',
+    path: ['ctaLabel'],
+  });
+
+export type AnnouncementInput = z.infer<typeof announcementInputSchema>;

--- a/src/domain/announcement/announcement.visibility.test.ts
+++ b/src/domain/announcement/announcement.visibility.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { selectVisibleAnnouncements, type AnnouncementForVisibility } from './announcement.visibility';
+
+// ─── Test fixtures ───────────────────────────────────────────
+
+const NOW = new Date('2026-07-21T12:00:00Z');
+const HOUR = 1000 * 60 * 60;
+
+let idCounter = 0;
+
+function createAnnouncement(overrides: Partial<AnnouncementForVisibility> = {}): AnnouncementForVisibility {
+  idCounter += 1;
+  return {
+    id: `announcement-${idCounter}`,
+    type: 'BANNER',
+    isActive: true,
+    expiresAt: null,
+    createdAt: new Date(NOW.getTime() - 24 * HOUR),
+    ...overrides,
+  };
+}
+
+const noDismissals = new Set<string>();
+
+// ─── Tests ───────────────────────────────────────────────────
+
+describe('selectVisibleAnnouncements', () => {
+  it('returns nothing for an empty list', () => {
+    const result = selectVisibleAnnouncements([], noDismissals, NOW);
+    assert.deepStrictEqual(result, { banner: null, modal: null });
+  });
+
+  it('returns an active banner', () => {
+    const banner = createAnnouncement();
+    const result = selectVisibleAnnouncements([banner], noDismissals, NOW);
+    assert.strictEqual(result.banner, banner);
+    assert.strictEqual(result.modal, null);
+  });
+
+  it('returns an active modal', () => {
+    const modal = createAnnouncement({ type: 'MODAL' });
+    const result = selectVisibleAnnouncements([modal], noDismissals, NOW);
+    assert.strictEqual(result.banner, null);
+    assert.strictEqual(result.modal, modal);
+  });
+
+  it('excludes inactive announcements', () => {
+    const inactive = createAnnouncement({ isActive: false });
+    const result = selectVisibleAnnouncements([inactive], noDismissals, NOW);
+    assert.deepStrictEqual(result, { banner: null, modal: null });
+  });
+
+  it('excludes expired announcements', () => {
+    const expired = createAnnouncement({ expiresAt: new Date(NOW.getTime() - 1) });
+    const result = selectVisibleAnnouncements([expired], noDismissals, NOW);
+    assert.deepStrictEqual(result, { banner: null, modal: null });
+  });
+
+  it('excludes an announcement expiring exactly now', () => {
+    const expiringNow = createAnnouncement({ expiresAt: NOW });
+    const result = selectVisibleAnnouncements([expiringNow], noDismissals, NOW);
+    assert.deepStrictEqual(result, { banner: null, modal: null });
+  });
+
+  it('includes an announcement expiring in the future', () => {
+    const future = createAnnouncement({ expiresAt: new Date(NOW.getTime() + HOUR) });
+    const result = selectVisibleAnnouncements([future], noDismissals, NOW);
+    assert.strictEqual(result.banner, future);
+  });
+
+  it('includes an announcement with no expiry', () => {
+    const noExpiry = createAnnouncement({ expiresAt: null });
+    const result = selectVisibleAnnouncements([noExpiry], noDismissals, NOW);
+    assert.strictEqual(result.banner, noExpiry);
+  });
+
+  it('excludes dismissed announcements', () => {
+    const dismissed = createAnnouncement();
+    const result = selectVisibleAnnouncements([dismissed], new Set([dismissed.id]), NOW);
+    assert.deepStrictEqual(result, { banner: null, modal: null });
+  });
+
+  it('picks the newest banner when several are active', () => {
+    const older = createAnnouncement({ createdAt: new Date(NOW.getTime() - 48 * HOUR) });
+    const newer = createAnnouncement({ createdAt: new Date(NOW.getTime() - 1 * HOUR) });
+    const result = selectVisibleAnnouncements([older, newer], noDismissals, NOW);
+    assert.strictEqual(result.banner, newer);
+  });
+
+  it('reveals the next-newest banner once the newest is dismissed (queue, not stack)', () => {
+    const older = createAnnouncement({ createdAt: new Date(NOW.getTime() - 48 * HOUR) });
+    const newer = createAnnouncement({ createdAt: new Date(NOW.getTime() - 1 * HOUR) });
+    const result = selectVisibleAnnouncements([older, newer], new Set([newer.id]), NOW);
+    assert.strictEqual(result.banner, older);
+  });
+
+  it('returns one banner and one modal at the same time', () => {
+    const banner = createAnnouncement();
+    const modal = createAnnouncement({ type: 'MODAL' });
+    const result = selectVisibleAnnouncements([banner, modal], noDismissals, NOW);
+    assert.strictEqual(result.banner, banner);
+    assert.strictEqual(result.modal, modal);
+  });
+
+  it('selects newest independently per type', () => {
+    const oldBanner = createAnnouncement({ createdAt: new Date(NOW.getTime() - 72 * HOUR) });
+    const newModal = createAnnouncement({ type: 'MODAL', createdAt: new Date(NOW.getTime() - 1 * HOUR) });
+    const newBanner = createAnnouncement({ createdAt: new Date(NOW.getTime() - 2 * HOUR) });
+    const oldModal = createAnnouncement({ type: 'MODAL', createdAt: new Date(NOW.getTime() - 96 * HOUR) });
+    const result = selectVisibleAnnouncements([oldBanner, newModal, newBanner, oldModal], noDismissals, NOW);
+    assert.strictEqual(result.banner, newBanner);
+    assert.strictEqual(result.modal, newModal);
+  });
+
+  it('never returns two modals', () => {
+    const modalA = createAnnouncement({ type: 'MODAL', createdAt: new Date(NOW.getTime() - 2 * HOUR) });
+    const modalB = createAnnouncement({ type: 'MODAL', createdAt: new Date(NOW.getTime() - 1 * HOUR) });
+    const result = selectVisibleAnnouncements([modalA, modalB], noDismissals, NOW);
+    assert.strictEqual(result.modal, modalB);
+    assert.strictEqual(result.banner, null);
+  });
+
+  it('combines all rules: dismissed, expired, and inactive are skipped in order', () => {
+    const dismissed = createAnnouncement({ createdAt: new Date(NOW.getTime() - 1 * HOUR) });
+    const expired = createAnnouncement({
+      createdAt: new Date(NOW.getTime() - 2 * HOUR),
+      expiresAt: new Date(NOW.getTime() - HOUR),
+    });
+    const inactive = createAnnouncement({ createdAt: new Date(NOW.getTime() - 3 * HOUR), isActive: false });
+    const visible = createAnnouncement({ createdAt: new Date(NOW.getTime() - 4 * HOUR) });
+    const result = selectVisibleAnnouncements(
+      [dismissed, expired, inactive, visible],
+      new Set([dismissed.id]),
+      NOW,
+    );
+    assert.strictEqual(result.banner, visible);
+  });
+});

--- a/src/domain/announcement/announcement.visibility.ts
+++ b/src/domain/announcement/announcement.visibility.ts
@@ -1,0 +1,37 @@
+// Pure visibility rules for announcements — no I/O, no framework types.
+// An announcement is visible when it is active, not expired, and not
+// dismissed by the current user. At most one BANNER and one MODAL are
+// shown at a time, newest first; dismissing reveals the next-newest.
+
+export interface AnnouncementForVisibility {
+  id: string;
+  type: 'BANNER' | 'MODAL';
+  isActive: boolean;
+  expiresAt: Date | null;
+  createdAt: Date;
+}
+
+export interface VisibleAnnouncements<T> {
+  banner: T | null;
+  modal: T | null;
+}
+
+export function selectVisibleAnnouncements<T extends AnnouncementForVisibility>(
+  announcements: readonly T[],
+  dismissedIds: ReadonlySet<string>,
+  now: Date,
+): VisibleAnnouncements<T> {
+  const eligible = announcements
+    .filter(
+      (a) =>
+        a.isActive &&
+        !dismissedIds.has(a.id) &&
+        (a.expiresAt === null || a.expiresAt.getTime() > now.getTime()),
+    )
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+  return {
+    banner: eligible.find((a) => a.type === 'BANNER') ?? null,
+    modal: eligible.find((a) => a.type === 'MODAL') ?? null,
+  };
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -35,6 +35,10 @@ export type AnalyticsEvent =
   // ── Feedback / support ───────────────────────────────────────────────
   | 'support_link_clicked'
   | 'bug_report_clicked'
+  // ── Announcements ────────────────────────────────────────────────────
+  | 'announcement_shown'
+  | 'announcement_dismissed'
+  | 'announcement_cta_clicked'
   // ── Documents ────────────────────────────────────────────────────────
   | 'document_upload_started'
   | 'document_upload_rejected'


### PR DESCRIPTION
## Summary

Implements the in-app announcements feature from PRD #91: admins create banner or modal announcements (markdown body, optional CTA such as a Google Form link, optional expiry) on a new `/admin/announcements` page; logged-in users see them on the dashboard, and dismissal is permanent per user across devices.

- **Schema**: `Announcement` + `AnnouncementDismissal` (migration `20260721120000_add_announcements`)
- **Domain**: `src/domain/announcement` following the domain convention; all display rules live in a pure `selectVisibleAnnouncements` function — active, not expired, not dismissed, newest-first, at most one banner + one modal
- **Dashboard**: banner above content, modal on load; X/ESC/outside-click permanently dismiss; CTA opens in a new tab and does not dismiss
- **Admin**: CRUD with activate/deactivate, expiry, and per-announcement dismissal counts; admin nav link
- **Analytics**: `announcement_shown` / `announcement_dismissed` / `announcement_cta_clicked` in the PostHog catalog

## Testing

- 30 new unit tests (visibility rules, Zod input schema) — 149 total pass
- `tsc --noEmit` clean, ESLint clean on all touched files, production build succeeds
- E2E scenario (#98) is closed as deferred: the Playwright+BDD framework only exists on the unmerged `test/bdd-tests` branch; the announcements scenario should be added once that lands (see issue comment)

Closes #91
Closes #92
Closes #93
Closes #94
Closes #95
Closes #96
Closes #97
Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="564" height="311" alt="Screenshot 2026-07-23 at 13 01 23" src="https://github.com/user-attachments/assets/421c4f4d-983b-4e8b-8c81-792392b745b3" />
<img width="5088" height="3412" alt="Translation Helper · 13 02 · 07-23 (1)" src="https://github.com/user-attachments/assets/ba9ea1b7-53ed-428d-b480-b54e097adfcd" />
<img width="5088" height="3412" alt="Translation Helper · 13 02 · 07-23" src="https://github.com/user-attachments/assets/db6c4427-b76d-4fb9-8b6b-ac8a2f07220a" />
<img width="3696" height="5088" alt="Translation Helper" src="https://github.com/user-attachments/assets/ce532188-9f8b-4fcc-a070-a1e99ef0c6b6" />

<img width="638" height="414" alt="Screenshot 2026-07-23 at 13 03 07" src="https://github.com/user-attachments/assets/abd8cb08-12b9-4cd0-9146-814c8a07c598" />
<img width="571" height="536" alt="Screenshot 2026-07-23 at 13 03 18" src="https://github.com/user-attachments/assets/d83fd6e1-cf8b-43bc-a777-5b44517cb29c" />
<img width="615" height="477" alt="Screenshot 2026-07-23 at 13 03 12" src="https://github.com/user-attachments/assets/823fb415-cfdf-4585-832f-8d2cbaf19d40" />


