### PR TITLE
fix: open projects in the user's assigned language

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/user/user-table.test.ts src/domain/user/user-csv.test.ts src/lib/format.test.ts src/domain/announcement/announcement.visibility.test.ts src/domain/announcement/announcement.types.test.ts",
+    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/user/user-table.test.ts src/domain/user/user-csv.test.ts src/lib/format.test.ts src/domain/announcement/announcement.visibility.test.ts src/domain/announcement/announcement.types.test.ts src/domain/language/resolve-initial-language.test.ts",
     "db:seed": "tsx prisma/seed.ts",
     "format": "prettier --write .",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",

--- a/src/app/projects/[sourceProjectId]/page.client.tsx
+++ b/src/app/projects/[sourceProjectId]/page.client.tsx
@@ -58,6 +58,8 @@ interface ProjectDetailClientProps {
       documentAssignments: number;
     };
   }[];
+  /** Resolved server-side from the user's assigned languages and this project's translation projects. */
+  initialLanguageId: string;
 }
 
 export default function ProjectDetailClient({
@@ -65,6 +67,7 @@ export default function ProjectDetailClient({
   sourceProject,
   languages,
   translationProjects,
+  initialLanguageId,
 }: ProjectDetailClientProps) {
   const router = useRouter();
   useAnalyticsProjectGroup(sourceProject.id, sourceProject.name);
@@ -76,7 +79,7 @@ export default function ProjectDetailClient({
   const [settingsIdentifier, setSettingsIdentifier] = useState(sourceProject.identifier || '');
   const [settingsSaving, setSettingsSaving] = useState(false);
 
-  const [selectedLanguage, setSelectedLanguage] = useState<string>(languages[0]?.id || '');
+  const [selectedLanguage, setSelectedLanguage] = useState<string>(initialLanguageId);
 
   // Register the active language as a PostHog super property (value is a language id)
   const selectedLang = languages.find((lang) => lang.id === selectedLanguage);

--- a/src/app/projects/[sourceProjectId]/page.tsx
+++ b/src/app/projects/[sourceProjectId]/page.tsx
@@ -3,6 +3,8 @@
 import { getSourceProjectAction } from '@/domain/source-project/source-project.actions';
 import { listTranslationProjectsAction } from '@/domain/translation-project/translation-project.actions';
 import { listTargetLanguages } from '@/domain/language/language.repository';
+import { resolveInitialLanguage } from '@/domain/language/resolve-initial-language';
+import { getUserLanguages } from '@/domain/user-language/user-language.repository';
 import { canAccessSourceProject } from '@/lib/permissions';
 import { getCurrentUser } from '@/lib/session';
 import { notFound, redirect } from 'next/navigation';
@@ -22,6 +24,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   const languages = await listTargetLanguages();
   const translationProjects = await listTranslationProjectsAction({ sourceProjectId });
+  const userLanguages = await getUserLanguages(user.id);
+
+  const initialLanguageId = resolveInitialLanguage({
+    userLanguageIds: userLanguages.map((userLanguage) => userLanguage.languageId),
+    projectLanguages: translationProjects.map((translationProject) => translationProject.language),
+  });
 
   return (
     <ProjectDetailClient
@@ -29,6 +37,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       sourceProject={sourceProject}
       languages={languages}
       translationProjects={translationProjects}
+      initialLanguageId={initialLanguageId}
     />
   );
 }

--- a/src/domain/language/resolve-initial-language.test.ts
+++ b/src/domain/language/resolve-initial-language.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveInitialLanguage } from './resolve-initial-language';
+
+const CROATIAN = { id: 'hr-id', name: 'Croatian' };
+const CZECH = { id: 'cs-id', name: 'Czech' };
+const GERMAN = { id: 'de-id', name: 'German' };
+const SLOVAK = { id: 'sk-id', name: 'Slovak' };
+
+describe('resolveInitialLanguage', () => {
+  describe('user is assigned a language on the project', () => {
+    it('picks the assigned language over the alphabetically first one', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: [CZECH.id],
+          projectLanguages: [CROATIAN, CZECH, GERMAN],
+        }),
+        CZECH.id,
+      );
+    });
+
+    it('picks the assigned language regardless of project language order', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: [SLOVAK.id],
+          projectLanguages: [SLOVAK, CROATIAN, CZECH],
+        }),
+        SLOVAK.id,
+      );
+    });
+
+    it('breaks ties alphabetically by name when several assigned languages match', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: [SLOVAK.id, CZECH.id, GERMAN.id],
+          projectLanguages: [CROATIAN, CZECH, GERMAN, SLOVAK],
+        }),
+        CZECH.id,
+      );
+    });
+
+    it('ignores assigned languages the project does not have', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: ['fr-id', GERMAN.id],
+          projectLanguages: [CROATIAN, GERMAN],
+        }),
+        GERMAN.id,
+      );
+    });
+  });
+
+  describe('user has no matching language on the project', () => {
+    it('falls back to the project language that sorts first', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: ['fr-id'],
+          projectLanguages: [GERMAN, CROATIAN],
+        }),
+        CROATIAN.id,
+      );
+    });
+
+    it('falls back when the user has no assigned languages at all', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: [],
+          projectLanguages: [SLOVAK, CZECH],
+        }),
+        CZECH.id,
+      );
+    });
+  });
+
+  describe('project has no translation projects', () => {
+    it('returns an empty string rather than an unrelated language', () => {
+      assert.equal(
+        resolveInitialLanguage({
+          userLanguageIds: [CZECH.id],
+          projectLanguages: [],
+        }),
+        '',
+      );
+    });
+
+    it('returns an empty string when nothing is known', () => {
+      assert.equal(resolveInitialLanguage({ userLanguageIds: [], projectLanguages: [] }), '');
+    });
+  });
+
+  it('does not mutate the caller’s project language array', () => {
+    const projectLanguages = [GERMAN, CROATIAN, CZECH];
+
+    resolveInitialLanguage({ userLanguageIds: [], projectLanguages });
+
+    assert.deepEqual(projectLanguages, [GERMAN, CROATIAN, CZECH]);
+  });
+});

--- a/src/domain/language/resolve-initial-language.ts
+++ b/src/domain/language/resolve-initial-language.ts
@@ -1,0 +1,34 @@
+export interface ProjectLanguage {
+  id: string;
+  name: string;
+}
+
+export interface ResolveInitialLanguageParams {
+  /** Language ids assigned to the current user (UserLanguage). */
+  userLanguageIds: string[];
+  /** Languages that actually have a translation project on this source project. */
+  projectLanguages: ProjectLanguage[];
+}
+
+/**
+ * Picks the language a project should open in for a given user.
+ *
+ * Preference order:
+ *  1. A language the user is assigned to that exists on this project.
+ *  2. Any language that exists on this project.
+ *  3. Nothing, when the project has no translation projects yet.
+ *
+ * Ties are broken alphabetically by language name, matching the `name: 'asc'`
+ * ordering used by the language and translation-project repositories.
+ *
+ * Deliberately never falls back to "the first language in the system" — doing so
+ * made every project open in the globally alphabetically-first language.
+ */
+export function resolveInitialLanguage({ userLanguageIds, projectLanguages }: ResolveInitialLanguageParams): string {
+  const available = [...projectLanguages].sort((a, b) => a.name.localeCompare(b.name));
+  const assigned = new Set(userLanguageIds);
+
+  const preferred = available.find((language) => assigned.has(language.id));
+
+  return preferred?.id ?? available[0]?.id ?? '';
+}

--- a/src/domain/user-language/user-language.repository.ts
+++ b/src/domain/user-language/user-language.repository.ts
@@ -1,6 +1,6 @@
 import prisma from '@/lib/db';
 
-async function getUserLanguages(userId: string) {
+export async function getUserLanguages(userId: string) {
   return prisma.userLanguage.findMany({
     where: {
       userId,


### PR DESCRIPTION
## Problem

Opening a project from the dashboard showed it in the wrong language — a language the user does not work in.

Root cause is a single line in `src/app/projects/[sourceProjectId]/page.client.tsx`:

```ts
const [selectedLanguage, setSelectedLanguage] = useState<string>(languages[0]?.id || '');
```

`languages` is **every target language in the system**, ordered `name: 'asc'` (`language.repository.ts`). So the initial selection was always the globally alphabetically-first language — Croatian, with the seeded dataset — for every user, on every project.

The per-project `localStorage` key (`project:<id>:selectedLanguage`) only corrected this in a `useEffect` that runs *after* first render, so it never helped on a project's **first** visit. That is exactly the reported symptom: a new project appears, you click it, and it opens in the wrong language.

## Note on the approach

The original report described taking "the default language from the DB". There is no such field — `isDefault`, `defaultLanguage`, `preferredLanguage` and `isPrimary` appear nowhere in `prisma/` or `src/`, and no migration has ever added one. `UserLanguage` is a plain join table with no default or ordering flag, and `setUserLanguages` deletes and recreates every row, so `createdAt` carries no meaning either.

Rather than add a schema field, this resolves from the data that already exists: the user's assigned languages, intersected with the languages the project actually has translation projects for.

## Change

Resolve the initial language **server-side** and pass it down as `initialLanguageId`:

1. A language the user is assigned to (`UserLanguage`) that exists on this project.
2. Otherwise, any language the project has.
3. Otherwise, empty — never a global first.

Ties break alphabetically by language name, matching the `orderBy: { name: 'asc' }` used by the language and translation-project repositories.

`localStorage` still takes precedence on subsequent visits, so an explicit language switch sticks. The existing persist effect writes the resolved default on first visit.

## Files

| File | Change |
|---|---|
| `src/domain/language/resolve-initial-language.ts` | new — pure `resolveInitialLanguage()` |
| `src/domain/language/resolve-initial-language.test.ts` | new — 9 cases |
| `src/app/projects/[sourceProjectId]/page.tsx` | resolves `initialLanguageId` server-side |
| `src/app/projects/[sourceProjectId]/page.client.tsx` | uses `initialLanguageId` instead of `languages[0]` |
| `src/domain/user-language/user-language.repository.ts` | exported `getUserLanguages` (was module-private) |
| `package.json` | registered the new test |

## Testing

The decision logic is a pure function so it is covered by the existing `tsx --test` runner, following the conventions in `document-version.transitions.test.ts` and friends.

- `pnpm test` — 190/190 pass (9 new)
- `tsc --noEmit` — clean
- `pnpm lint` — unchanged from baseline (217 pre-existing problems before and after; the 4 errors in `page.client.tsx` are pre-existing `any` types, shifted by 3 lines)

Not verified against a running database — the end-to-end reproduction was not exercised.

## Reviewer note

To reproduce the fix you need a project you have **never opened**, or clear the `project:<id>:selectedLanguage` localStorage keys. Projects with an existing stored value keep it by design.

## Out of scope

The language dropdown still lists all global target languages, including ones with no translation project on the current source project — selecting one shows an empty board. Left alone deliberately to keep this fix minimal; worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)