### PR TITLE
fix: crash when saving user languages in the admin users table

### DIFF
--- a/prisma/seed-data/datasets.ts
+++ b/prisma/seed-data/datasets.ts
@@ -70,9 +70,12 @@ export const FOLDERS = ['Exodus90 - 2026', 'Advent 2025'];
 // Users
 // ---------------------------------------------------------------------------
 
+// English is the source language, not a target: nobody is assigned it. The admin
+// UI only ever offers target languages, so an `en` assignment is a state the app
+// cannot produce or manage — seeding one made the users table crash on save.
 export const USERS = [
-  { key: 'admin1', email: 'admin@example.org', name: 'Fr. Thomas More', role: Role.ADMIN, langCodes: ['en', 'cs', 'sk'] },
-  { key: 'admin2', email: 'admin2@example.org', name: 'Sarah Mitchell', role: Role.ADMIN, langCodes: ['en', 'de', 'fr'] },
+  { key: 'admin1', email: 'admin@example.org', name: 'Fr. Thomas More', role: Role.ADMIN, langCodes: ['cs', 'sk'] },
+  { key: 'admin2', email: 'admin2@example.org', name: 'Sarah Mitchell', role: Role.ADMIN, langCodes: ['de', 'fr'] },
   { key: 'translator1', email: 'translator@example.org', name: 'Jan Novak', role: Role.USER, langCodes: ['cs', 'sk'] },
   { key: 'translator2', email: 'translator2@example.org', name: 'Maria Schmidt', role: Role.USER, langCodes: ['de'] },
   { key: 'reviewer1', email: 'reviewer@example.org', name: 'Ivan Horvat', role: Role.USER, langCodes: ['hr', 'sk'] },

--- a/src/app/admin/users/page.client.tsx
+++ b/src/app/admin/users/page.client.tsx
@@ -39,7 +39,7 @@ import {
 } from '@/domain/invitation/invitation.display-status';
 import { adminSetUserLanguagesAction } from '@/domain/user-language/user-language.actions';
 import { buildUserCsv } from '@/domain/user/user-csv';
-import { compareByLanguageThenName, matchesSearch } from '@/domain/user/user-table';
+import { compareByLanguageThenName, matchesSearch, resolveSelectedLanguages } from '@/domain/user/user-table';
 import { formatExactDateTime, formatLastActive, formatUnambiguousDate } from '@/lib/format';
 import { downloadCsv } from '@/lib/download';
 import { adminUpdateUserProfileAction, updateUserRoleAction } from '@/domain/user/user.actions';
@@ -404,15 +404,13 @@ export default function UsersClient({
     setLoading(true);
     try {
       await adminSetUserLanguagesAction(languageUser.id, selectedLanguageIds);
+      // Resolve against the user's current languages too: the dialog only offers
+      // target languages, so an already-assigned English would not resolve.
+      const knownLanguages = [...availableLanguages, ...languageUser.languages.map((ul) => ul.language)];
       setUsers(
         users.map((u) =>
           u.id === languageUser.id
-            ? {
-                ...u,
-                languages: selectedLanguageIds.map((id) => ({
-                  language: availableLanguages.find((l) => l.id === id)!,
-                })),
-              }
+            ? { ...u, languages: resolveSelectedLanguages(selectedLanguageIds, knownLanguages) }
             : u,
         ),
       );

--- a/src/domain/user/user-table.test.ts
+++ b/src/domain/user/user-table.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   compareByLanguageThenName,
   matchesSearch,
+  resolveSelectedLanguages,
   type UserTableRow,
   type UserSearchRow,
 } from './user-table';
@@ -15,28 +16,25 @@ function user(name: string, languages: Array<[string, string]> = []): UserTableR
   return { name, languages: languages.map(([id, n]) => lang(id, n)) };
 }
 
-function searchUser(
-  name: string,
-  email: string,
-  languages: Array<[string, string]> = [],
-): UserSearchRow {
+function searchUser(name: string, email: string, languages: Array<[string, string]> = []): UserSearchRow {
   return { name, email, languages: languages.map(([id, n]) => lang(id, n)) };
 }
 
 describe('compareByLanguageThenName', () => {
   it('orders by first language alphabetically', () => {
-    const result = [user('Klaus', [['de', 'German']]), user('Anna', [['cs', 'Czech']])].sort(
-      compareByLanguageThenName,
+    const result = [user('Klaus', [['de', 'German']]), user('Anna', [['cs', 'Czech']])].sort(compareByLanguageThenName);
+    assert.deepEqual(
+      result.map((u) => u.name),
+      ['Anna', 'Klaus'],
     );
-    assert.deepEqual(result.map((u) => u.name), ['Anna', 'Klaus']);
   });
 
   it('orders by name within the same language', () => {
-    const result = [
-      user('Petr', [['cs', 'Czech']]),
-      user('Anna', [['cs', 'Czech']]),
-    ].sort(compareByLanguageThenName);
-    assert.deepEqual(result.map((u) => u.name), ['Anna', 'Petr']);
+    const result = [user('Petr', [['cs', 'Czech']]), user('Anna', [['cs', 'Czech']])].sort(compareByLanguageThenName);
+    assert.deepEqual(
+      result.map((u) => u.name),
+      ['Anna', 'Petr'],
+    );
   });
 
   it('uses the alphabetically-first language for multi-language users', () => {
@@ -44,22 +42,31 @@ describe('compareByLanguageThenName', () => {
     // German-only user despite the German membership.
     const result = [
       user('Klaus', [['de', 'German']]),
-      user('Boris', [['de', 'German'], ['cs', 'Czech']]),
+      user('Boris', [
+        ['de', 'German'],
+        ['cs', 'Czech'],
+      ]),
     ].sort(compareByLanguageThenName);
-    assert.deepEqual(result.map((u) => u.name), ['Boris', 'Klaus']);
+    assert.deepEqual(
+      result.map((u) => u.name),
+      ['Boris', 'Klaus'],
+    );
   });
 
   it('sorts users with no language after everyone else', () => {
-    const result = [
-      user('NoLang'),
-      user('Anna', [['cs', 'Czech']]),
-    ].sort(compareByLanguageThenName);
-    assert.deepEqual(result.map((u) => u.name), ['Anna', 'NoLang']);
+    const result = [user('NoLang'), user('Anna', [['cs', 'Czech']])].sort(compareByLanguageThenName);
+    assert.deepEqual(
+      result.map((u) => u.name),
+      ['Anna', 'NoLang'],
+    );
   });
 
   it('orders two no-language users by name', () => {
     const result = [user('Zoe'), user('Adam')].sort(compareByLanguageThenName);
-    assert.deepEqual(result.map((u) => u.name), ['Adam', 'Zoe']);
+    assert.deepEqual(
+      result.map((u) => u.name),
+      ['Adam', 'Zoe'],
+    );
   });
 });
 
@@ -91,5 +98,56 @@ describe('matchesSearch', () => {
   it('does not match an unrelated query', () => {
     assert.equal(matchesSearch(anna, 'german'), false);
     assert.equal(matchesSearch(anna, 'zzz'), false);
+  });
+});
+
+describe('resolveSelectedLanguages', () => {
+  const ENGLISH = { id: 'en-id', name: 'English' };
+  const CZECH = { id: 'cs-id', name: 'Czech' };
+  const SLOVAK = { id: 'sk-id', name: 'Slovak' };
+
+  // The admin dialog only offers target languages, so English is never in it.
+  const assignable = [CZECH, SLOVAK];
+
+  it('resolves ids to their language objects, preserving selection order', () => {
+    assert.deepEqual(resolveSelectedLanguages([SLOVAK.id, CZECH.id], assignable), [
+      { language: SLOVAK },
+      { language: CZECH },
+    ]);
+  });
+
+  it('resolves an already-assigned English when it is among the known languages', () => {
+    assert.deepEqual(resolveSelectedLanguages([ENGLISH.id, CZECH.id], [...assignable, ENGLISH]), [
+      { language: ENGLISH },
+      { language: CZECH },
+    ]);
+  });
+
+  it('never yields an entry with an undefined language', () => {
+    const resolved = resolveSelectedLanguages([ENGLISH.id, CZECH.id], assignable);
+
+    assert.deepEqual(resolved, [{ language: CZECH }]);
+    assert.ok(resolved.every((entry) => entry.language !== undefined));
+  });
+
+  it('keeps the result usable by the table consumers that crashed', () => {
+    const resolved = resolveSelectedLanguages([ENGLISH.id, CZECH.id], assignable);
+
+    // These are the exact reads that threw: the languages accessorFn and the sorter.
+    assert.deepEqual(
+      resolved.map((ul) => ul.language.id),
+      [CZECH.id],
+    );
+    assert.doesNotThrow(() =>
+      compareByLanguageThenName({ name: 'Anna', languages: resolved }, { name: 'Bob', languages: [] }),
+    );
+  });
+
+  it('returns an empty list when nothing is selected', () => {
+    assert.deepEqual(resolveSelectedLanguages([], assignable), []);
+  });
+
+  it('returns an empty list when nothing resolves', () => {
+    assert.deepEqual(resolveSelectedLanguages([ENGLISH.id], assignable), []);
   });
 });

--- a/src/domain/user/user-table.ts
+++ b/src/domain/user/user-table.ts
@@ -2,8 +2,36 @@
 // "language-then-name" ordering. Kept free of React/Prisma so it can be unit
 // tested in isolation (see user-table.test.ts).
 
+export interface LanguageRef {
+  id: string;
+  name: string;
+}
+
 export interface UserLanguageRef {
-  language: { id: string; name: string };
+  language: LanguageRef;
+}
+
+/**
+ * Rebuilds a user's language list from the ids an admin selected, resolving each
+ * id against the languages we know about.
+ *
+ * `knownLanguages` must include both the assignable languages and the user's
+ * current ones: the selectable list excludes English (`listTargetLanguages`),
+ * while a user may already be assigned English, so resolving against the
+ * selectable list alone leaves holes. Unresolvable ids are dropped rather than
+ * asserted away — a `{ language: undefined }` entry crashes every consumer that
+ * reads `language.id` or `language.name`.
+ */
+export function resolveSelectedLanguages<T extends LanguageRef>(
+  selectedLanguageIds: string[],
+  knownLanguages: T[],
+): { language: T }[] {
+  const byId = new Map(knownLanguages.map((language) => [language.id, language]));
+
+  return selectedLanguageIds
+    .map((id) => byId.get(id))
+    .filter((language): language is T => language !== undefined)
+    .map((language) => ({ language }));
 }
 
 export interface UserTableRow {


### PR DESCRIPTION
## Problem

Saving the **Edit Languages** dialog in `/admin/users` took the whole page down with `Application error: a client-side exception has occurred`.

## Root cause

The optimistic state update rebuilt the user's languages like this:

```ts
languages: selectedLanguageIds.map((id) => ({
  language: availableLanguages.find((l) => l.id === id)!,
})),
```

`availableLanguages` comes from `listTargetLanguages()`, which **excludes English** (`code != 'en'`). A user already assigned English keeps that id in `selectedLanguageIds` — the dialog renders no checkbox for English, so it cannot be deselected. `.find()` therefore returned `undefined`, and the `!` non-null assertion waved it straight past TypeScript.

The resulting `{ language: undefined }` entry then threw in three places that read through it: the `languages` `accessorFn`, `firstLanguageName` in the sorter, and the cell renderer. The table sorts by languages **by default**, so it fired on the very next render.

Reproduced against the real `compareByLanguageThenName`:

```
old optimistic state: [{},{"language":{"id":"cs-id","name":"Czech"}}]
accessorFn THREW -> Cannot read properties of undefined (reading 'id')
sorter THREW     -> Cannot read properties of undefined (reading 'name')
```

## Fix

Added `resolveSelectedLanguages()` to `src/domain/user/user-table.ts` — the existing pure-logic module for this table. It resolves ids against the assignable languages **plus the user's current ones**, and drops ids that do not resolve rather than asserting them away. The `!` is gone.

Deliberately *not* filtered at the render site: that would have masked the hole while leaving client state disagreeing with what the server actually persisted, since `adminSetUserLanguagesAction` receives the English id and saves it.

## Seed change

The only thing that could produce an English assignment was the seed:

```ts
{ key: 'admin1', ..., langCodes: ['en', 'cs', 'sk'] }
{ key: 'admin2', ..., langCodes: ['en', 'de', 'fr'] }
```

Checked against production: **123 users, none assigned English, and no invitation offering it.** That is not an accident — the admin UI only ever offers target languages, so an `en` assignment is a state the app can neither produce nor manage. The seed was generating data the application cannot represent.

English **remains** a `Language` row: it is the source language, and `seed.ts:260` needs `langs.en` for every document's English version. `admin1` still authors those versions without being assigned English — exactly production's shape, where the US team uploads English source without holding English as a user language. Authorship and language assignment were never coupled.

The language list itself is unchanged.

## Why both changes

The seed fix stops this happening today; the code fix stops it if an `en` assignment ever arrives by another route. Neither makes the other redundant.

## Testing

`resolveSelectedLanguages` is pure, so it is covered by the existing `tsx --test` runner alongside the other `user-table` specs.

- `pnpm test` — 187/187 pass (6 new, including one asserting the exact reads that threw)
- `tsc --noEmit` — clean
- `pnpm lint` — unchanged from baseline (same pre-existing `any` errors, shifted 2 lines)

`pnpm db:seed` was **not** run — it needs a local database and wipes local dev data.

## Known limitation, not addressed here

An admin still cannot *see* or *remove* English on a user, because the dialog renders only target languages. That is now unreachable with the seed fixed, but it would matter if English ever became a legitimate user language (e.g. to model the US upload team). Enabling that means switching `/admin/users` to `listLanguages()` — a deliberate feature decision, not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)