### PR TITLE
chore: clear lint warnings introduced by the data table

### DIFF
--- a/src/app/admin/users/page.client.tsx
+++ b/src/app/admin/users/page.client.tsx
@@ -723,7 +723,6 @@ export default function UsersClient({
     ],
     // The dialog-open handlers only call state setters, so stale closures are
     // harmless — the memo only needs to react to the filter option lists.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [languageOptions],
   );
 

--- a/src/components/data-table/data-table-faceted-filter.tsx
+++ b/src/components/data-table/data-table-faceted-filter.tsx
@@ -40,8 +40,11 @@ export function DataTableFacetedFilter<TData, TValue>({
   const [open, setOpen] = React.useState(false);
 
   const columnFilterValue = column?.getFilterValue();
-  const selectedValues = new Set(
-    Array.isArray(columnFilterValue) ? columnFilterValue : [],
+  // Memoized so the identity is stable: onItemSelect/onReset depend on it, and a
+  // fresh Set on every render would rebuild those callbacks each time.
+  const selectedValues = React.useMemo(
+    () => new Set(Array.isArray(columnFilterValue) ? columnFilterValue : []),
+    [columnFilterValue],
   );
 
   const onItemSelect = React.useCallback(

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -244,6 +244,10 @@ export function useDataTable<TData>(props: UseDataTableProps<TData>) {
     [debouncedSetFilterValues, filterableColumns],
   );
 
+  // React Compiler cannot memoize around useReactTable: TanStack returns
+  // functions whose identity it cannot prove stable, so it skips compiling this
+  // hook. That is inherent to the library and not something we can restructure.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     ...tableProps,
     columns,

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -1,6 +1,9 @@
 import type { ColumnSort, RowData } from "@tanstack/react-table";
 
 declare module "@tanstack/react-table" {
+  // The generic parameters are unused here but must match TanStack's own
+  // ColumnMeta signature for declaration merging to apply.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string;
     placeholder?: string;


### PR DESCRIPTION
## Why

Blocking the v1.2.0 release. `docs/RELEASE.md` lists `pnpm test && pnpm lint` passing as a precondition. Lint has been red for a while, but the admin users data table (#90) added **5 new warnings**, taking the project from 25 → 30.

This clears exactly those 5, returning lint to the `v1.1.2` baseline so the release adds no new lint debt.

## Changes

| File | Warning | Fix |
|---|---|---|
| `data-table-faceted-filter.tsx:43` | `selectedValues` object construction breaks the `useCallback` at line 65 | Wrapped in `useMemo` keyed on `columnFilterValue`, so the Set identity is stable instead of fresh every render |
| `admin/users/page.client.tsx:726` | Unused `eslint-disable` directive | Removed the directive; the explanatory comment above it stays |
| `types/data-table.ts:4` | `TData` / `TValue` unused (×2) | Cannot be deleted — they must match TanStack's `ColumnMeta` signature for declaration merging. Rule disabled with the reason recorded |
| `hooks/use-data-table.ts:247` | `react-hooks/incompatible-library` | Not fixable in our code: React Compiler skips memoizing because TanStack's `useReactTable` returns functions whose identity it cannot prove stable. Rule disabled with the reason recorded |

Two of the four are genuine fixes; two are suppressions of things that cannot be restructured away, each with the reasoning written down rather than a bare disable.

## Result

```
before: 217 problems (187 errors, 30 warnings)
after:  212 problems (187 errors, 25 warnings)   ← identical to v1.1.2
```

Verified by diffing the full warning list against `v1.1.2`: **zero remaining new warnings**.

## Not addressed

The **187 pre-existing errors** (overwhelmingly `@typescript-eslint/no-explicit-any`) are untouched — they predate the last release and clearing them is a separate piece of work worth its own issue. This PR only ensures the upcoming release doesn't add to the pile.

## Testing

- `pnpm test` — 196/196 pass
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)