### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [1.2.0](https://github.com/exodus-international/translator-helper/compare/v1.1.2...v1.2.0) (2026-08-04)
+
+
+### Bug Fixes
+
+* crash when saving user languages in the admin users table ([#102](https://github.com/exodus-international/translator-helper/issues/102)) ([9e2fa69](https://github.com/exodus-international/translator-helper/commit/9e2fa69221c46bf3c40c18c4363c058ff6d1eb6a))
+* open projects in the user's assigned language ([#101](https://github.com/exodus-international/translator-helper/issues/101)) ([7a89b7e](https://github.com/exodus-international/translator-helper/commit/7a89b7e0a4a8144439d3f94fd4af81332e44f355))
+
+
+### Features
+
+* admin users data table with activity columns ([#90](https://github.com/exodus-international/translator-helper/issues/90)) ([ebcfb61](https://github.com/exodus-international/translator-helper/commit/ebcfb616c80f9a51b71cc2c1adaf146e45ec9d46)), closes [#75](https://github.com/exodus-international/translator-helper/issues/75) [#74](https://github.com/exodus-international/translator-helper/issues/74) [#76](https://github.com/exodus-international/translator-helper/issues/76) [#74](https://github.com/exodus-international/translator-helper/issues/74) [#77](https://github.com/exodus-international/translator-helper/issues/77) [#74](https://github.com/exodus-international/translator-helper/issues/74) [#78](https://github.com/exodus-international/translator-helper/issues/78) [#74](https://github.com/exodus-international/translator-helper/issues/74) [#79](https://github.com/exodus-international/translator-helper/issues/79) [#74](https://github.com/exodus-international/translator-helper/issues/74) [#79](https://github.com/exodus-international/translator-helper/issues/79) [#81](https://github.com/exodus-international/translator-helper/issues/81)
+* in-app announcements (banner/modal with CTA) ([#99](https://github.com/exodus-international/translator-helper/issues/99)) ([6e9c3f2](https://github.com/exodus-international/translator-helper/commit/6e9c3f286fcace1f5b7f430a027fd52e5a173b5c)), closes [#92](https://github.com/exodus-international/translator-helper/issues/92) [#92](https://github.com/exodus-international/translator-helper/issues/92) [#93](https://github.com/exodus-international/translator-helper/issues/93) [#93](https://github.com/exodus-international/translator-helper/issues/93) [#94](https://github.com/exodus-international/translator-helper/issues/94) [#94](https://github.com/exodus-international/translator-helper/issues/94) [#95](https://github.com/exodus-international/translator-helper/issues/95) [#95](https://github.com/exodus-international/translator-helper/issues/95) [#96](https://github.com/exodus-international/translator-helper/issues/96) [#96](https://github.com/exodus-international/translator-helper/issues/96) [#97](https://github.com/exodus-international/translator-helper/issues/97) [#97](https://github.com/exodus-international/translator-helper/issues/97)
 ## 1.1.2 (2026-07-20)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helper",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "engines": {
     "node": ">=20.18.1"


### PR DESCRIPTION
Version bump and changelog for v1.2.0. Merge into `develop`, then open the promote PR `develop → production`.

## What's in this release (v1.1.2 → v1.2.0)

**Features**
- Admin users data table with activity columns (#90)
- In-app announcements — banner/modal with CTA (#99)

**Fixes**
- Crash when saving user languages in the admin users table (#102)
- Open projects in the user's assigned language (#101)

**Chores**
- Fix release tagging and changelog generation (#89)
- Clear lint warnings introduced by the data table (#103)

## Database migrations

Three migrations will apply on the production deploy. All are additive or widening — backward-compatible with the currently deployed code:

| Migration | Change |
| --- | --- |
| `20260721120000_add_announcements` | New `AnnouncementType` enum, `announcement` + `announcement_dismissal` tables |
| `20260721131450_add_user_activity_indexes` | Two new indexes on `activity_log` and `session` |
| `20260723120000_make_announcement_body_nullable` | `announcement.body` drops `NOT NULL` |

No columns or tables are dropped.

## Preconditions

- `pnpm test` — 196/196 passing
- `pnpm lint` — fails with 187 pre-existing errors across ~65 files (mostly `no-explicit-any`), unchanged by this release; `eslint.config.mjs` and the lint script have not changed since v1.1.2