### PR TITLE
fix: extract release notes for minor and major releases

### DIFF
--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -54,12 +54,14 @@ git push origin "$VERSION"
 # CHANGELOG section for this version when extractable, otherwise auto-generated.
 if command -v gh >/dev/null 2>&1; then
   notes_file="$(mktemp)"
-  # Extract the "## [X.Y.Z]" (or "## X.Y.Z") section from CHANGELOG.md.
-  # Stop at the next "## " version heading only — "###" subsection headings
-  # (e.g. "### Bug Fixes") are part of the section and must not end capture.
+  # Extract the "[X.Y.Z]" (or "X.Y.Z") section from CHANGELOG.md. The heading
+  # level varies: conventional-changelog's angular preset writes minor/major
+  # releases as "# " and patches as "## ", so match any run of "#".
+  # Stop at the next *version* heading — a heading is only a version heading if
+  # a digit (or "[") follows, so "### Bug Fixes" stays part of the section.
   awk -v ver="${VERSION#v}" '
-    $0 ~ "^## \\[?" ver "\\]?" {capture=1; next}
-    capture && /^## / {exit}
+    $0 ~ "^#+ \\[?" ver "\\]?" {capture=1; next}
+    capture && /^#+ \[?[0-9]+\.[0-9]+\.[0-9]+/ {exit}
     capture {print}
   ' CHANGELOG.md > "$notes_file" || true
 


### PR DESCRIPTION
Found while tagging **v1.2.0** — the GitHub Release came out with auto-generated notes instead of the CHANGELOG section, and I patched it by hand after the fact.

## The bug

`scripts/release-tag.sh` extracted a version's section from `CHANGELOG.md` by matching `^## <version>`:

```awk
$0 ~ "^## \\[?" ver "\\]?" {capture=1; next}
capture && /^## / {exit}
```

But conventional-changelog's angular preset varies the heading level:

- minor / major → **h1**, `# [1.2.0](…compare/v1.1.2...v1.2.0) (2026-08-04)`
- patch → **h2**, `## 1.1.2 (2026-07-20)`

So for any minor or major release the match never fired, `$notes_file` came back empty, and the script fell through to its `--generate-notes` fallback (`release-tag.sh:70`). It failed quietly — the release still gets created, just with the wrong notes.

`v1.0.0` and `v1.1.2` were both patches, which is why this survived until now. Every future `minor`/`major` release would have hit it.

## The fix

- Match any run of `#` for the version heading, so h1 and h2 both work.
- End capture at the next *version* heading rather than any `##` — a heading only counts as a version heading if a digit or `[` follows the hashes, which keeps `### Bug Fixes` / `### Features` subsections inside the section.

Deliberately avoids awk interval expressions (`{1,2}`) for portability.

## Verification

Ran the new awk against every section currently in `CHANGELOG.md`:

| Version | Heading | Extracted |
| --- | --- | --- |
| 1.2.0 | h1 | ✅ Bug Fixes (2) + Features (2), stops at 1.1.2 |
| 1.1.2 | h2 | ✅ Bug Fixes (1) |
| 1.1.0 | h2 | ✅ Features (2) + Bug Fixes (1) |
| 1.0.0 | h2 | ✅ final section |

`bash -n` clean. No behavior change for patch releases.