### PR TITLE
feat(audio): generate audio on approval and play it on the review page

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fflate": "^0.8.3",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.553.0",
     "next": "16.0.7",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/audio/audio.script.test.ts src/domain/audio/audio.ssml.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/user/user-table.test.ts src/domain/user/user-csv.test.ts src/lib/format.test.ts src/domain/announcement/announcement.visibility.test.ts src/domain/announcement/announcement.types.test.ts src/domain/language/resolve-initial-language.test.ts",
+    "test": "tsx --test src/domain/translation/translation.service.test.ts src/domain/audio/audio.script.test.ts src/domain/audio/audio.ssml.test.ts src/domain/audio/audio.paths.test.ts src/domain/github/github.paths.test.ts src/domain/document/validate-filename.test.ts src/domain/document/document.types.test.ts src/components/document-form/content-format.test.ts src/lib/authorize.test.ts src/domain/document-version/document-version.transitions.test.ts src/domain/invitation/invitation.validation.test.ts src/domain/invitation/invitation.types.test.ts src/domain/invitation/invitation.display-status.test.ts src/domain/user/user-table.test.ts src/domain/user/user-csv.test.ts src/lib/format.test.ts src/domain/announcement/announcement.visibility.test.ts src/domain/announcement/announcement.types.test.ts src/domain/language/resolve-initial-language.test.ts",
     "db:seed": "tsx prisma/seed.ts",
     "format": "prettier --write .",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
@@ -21,6 +21,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1117.0",
     "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1117.0
+        version: 3.1117.0
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.4.1(@date-fns/tz@1.5.0)(@types/react@19.2.4)(date-fns@4.4.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -180,6 +183,78 @@ packages:
 
   '@apm-js-collab/tracing-hooks@0.3.1':
     resolution: {integrity: sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==}
+
+  '@aws-sdk/checksums@3.1000.29':
+    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1117.0':
+    resolution: {integrity: sha512-M/zyjg0u0Sxm73sInvyDb9+/YUuAOz8/xxmcmj0quJ7NXllZqXPxzjti3oVDz/lQ5mDf7iuxBLc0Y3deJI2hRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2285,6 +2360,30 @@ packages:
     resolution: {integrity: sha512-HcWLW28yTMGXpwE9VLx9J+N2KEUaELadLrkPEEI9tpI5la70xNEVEsu/C+m3u7uoq4FulLqZQhgBCzR9IZhFpA==}
     engines: {node: '>=20.0.0'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -2875,6 +2974,9 @@ packages:
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -5162,6 +5264,171 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@aws-sdk/checksums@3.1000.29':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1117.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.29
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -7358,6 +7625,39 @@ snapshots:
       '@peculiar/asn1-x509': 2.5.0
       '@peculiar/x509': 1.14.0
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.0.0': {}
 
   '@swc/helpers@0.5.15':
@@ -7958,6 +8258,8 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   bottleneck@2.19.5: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -3414,6 +3417,9 @@ packages:
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -8678,6 +8684,8 @@ snapshots:
       picomatch: 4.0.3
 
   fflate@0.4.8: {}
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/prisma/migrations/20260825101029_add_audio_files/migration.sql
+++ b/prisma/migrations/20260825101029_add_audio_files/migration.sql
@@ -1,0 +1,46 @@
+-- CreateEnum
+CREATE TYPE "AudioProvider" AS ENUM ('AZURE_SPEECH');
+
+-- CreateEnum
+CREATE TYPE "AudioStatus" AS ENUM ('PENDING', 'PROCESSING', 'READY', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "language" ADD COLUMN     "audioProvider" "AudioProvider",
+ADD COLUMN     "audioVoice" TEXT;
+
+-- AlterTable
+ALTER TABLE "source_project" ADD COLUMN     "audioDocumentTypes" "DocumentType"[] DEFAULT ARRAY['DAY', 'DAILY_CONTENT']::"DocumentType"[];
+
+-- CreateTable
+CREATE TABLE "audio_file" (
+    "id" TEXT NOT NULL,
+    "documentVersionId" TEXT NOT NULL,
+    "status" "AudioStatus" NOT NULL DEFAULT 'PENDING',
+    "provider" "AudioProvider" NOT NULL,
+    "voice" TEXT NOT NULL,
+    "sourceVersion" INTEGER NOT NULL,
+    "providerJobId" TEXT,
+    "objectKey" TEXT,
+    "url" TEXT,
+    "durationMs" INTEGER,
+    "sizeBytes" INTEGER,
+    "billedCharacters" INTEGER,
+    "errorMessage" TEXT,
+    "triggeredByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "audio_file_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "audio_file_documentVersionId_createdAt_idx" ON "audio_file"("documentVersionId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "audio_file_status_updatedAt_idx" ON "audio_file"("status", "updatedAt");
+
+-- AddForeignKey
+ALTER TABLE "audio_file" ADD CONSTRAINT "audio_file_documentVersionId_fkey" FOREIGN KEY ("documentVersionId") REFERENCES "document_version"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "audio_file" ADD CONSTRAINT "audio_file_triggeredByUserId_fkey" FOREIGN KEY ("triggeredByUserId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,17 @@ enum GitHubPRStatus {
   CLOSED
 }
 
+enum AudioProvider {
+  AZURE_SPEECH
+}
+
+enum AudioStatus {
+  PENDING
+  PROCESSING
+  READY
+  FAILED
+}
+
 enum AnnouncementType {
   BANNER
   MODAL
@@ -115,6 +126,7 @@ model User {
   assignedByDocuments DocumentAssignment[] @relation("AssignedBy")
   languages           UserLanguage[]
   suggestions         Suggestion[]
+  triggeredAudioFiles AudioFile[]
   suggestionReplies   SuggestionReply[]
   invitationsCreated  Invitation[]     @relation("InvitationsCreated")
   announcementDismissals AnnouncementDismissal[]
@@ -176,6 +188,8 @@ model Language {
   name                    String // e.g., "English", "Czech", "German"
   translationInstructions String?              @db.Text
   branchName              String?
+  audioProvider           AudioProvider?
+  audioVoice              String? // provider voice id, e.g. "cs-CZ-AntoninNeural"
   createdAt               DateTime             @default(now())
   updatedAt               DateTime             @updatedAt
   documentVersions        DocumentVersion[]
@@ -202,6 +216,7 @@ model SourceProject {
   description         String?              @db.Text
   identifier          String?
   status              SourceProjectStatus  @default(ACTIVE)
+  audioDocumentTypes  DocumentType[]       @default([DAY, DAILY_CONTENT])
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
   documents           Document[]
@@ -298,6 +313,7 @@ model DocumentVersion {
   activityLogs  ActivityLog[]
   suggestions   Suggestion[]
   githubCommits GitHubCommit[]
+  audioFiles    AudioFile[]
 
   @@unique([documentId, languageId])
   @@map("document_version")
@@ -407,6 +423,34 @@ model GitHubCommit {
   updatedAt         DateTime        @updatedAt
 
   @@map("github_commit")
+}
+
+/// One row per audio generation attempt. Never overwritten: a regeneration
+/// creates a new row and a new object, so a copied URL keeps pointing at the
+/// file it pointed at when it was copied.
+model AudioFile {
+  id                String          @id @default(uuid())
+  documentVersionId String
+  documentVersion   DocumentVersion @relation(fields: [documentVersionId], references: [id], onDelete: Cascade)
+  status            AudioStatus     @default(PENDING)
+  provider          AudioProvider
+  voice             String
+  sourceVersion     Int // DocumentVersion.version the audio was generated from
+  providerJobId     String?
+  objectKey         String?
+  url               String?
+  durationMs        Int?
+  sizeBytes         Int?
+  billedCharacters  Int?
+  errorMessage      String?         @db.Text
+  triggeredByUserId String?
+  triggeredBy       User?           @relation(fields: [triggeredByUserId], references: [id], onDelete: SetNull)
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+
+  @@index([documentVersionId, createdAt])
+  @@index([status, updatedAt])
+  @@map("audio_file")
 }
 
 model Invitation {

--- a/prisma/seed-data/content.ts
+++ b/prisma/seed-data/content.ts
@@ -446,225 +446,225 @@ Find a quiet place outside. Sit for 15 minutes. Do nothing. Simply notice what y
 };
 
 const CZECH_CONTENT: Record<string, string> = {
-  'ex-d1': `# Den 1 - Povolani
+  'ex-d1': `# Den 1 – Povolání
 
-> "Pojdte za mnou a ucinim z vas rybare lidi." — Matous 4,19
+> "Pojďte za mnou a učiním z vás rybáře lidí." — Matouš 4,19
 
-## Ranni rozjimani
+## Ranní rozjímání
 
-Dnes zacinite svou 90denni cestu. Stejne jako apostolove, kteri zanechali sve site, jste volani k necemu vetsimu. Toto neni pouhé cviceni v sebeodrikani — je to pozvani k setkani s zivym Bohem.
+Dnes začínáte svou 90denní cestu. Stejně jako apoštolové, kteří zanechali své sítě, jste voláni k něčemu většímu. Toto není pouhé cvičení v sebeodříkání — je to pozvání k setkání s živým Bohem.
 
-### Tri pilire pro dnesek
+### Tři pilíře pro dnešek
 
-1. **Modlitba**: Stravte 20 minut v tiche modlitbe. Najdete klidne misto a budte jednoduze pritomni Bohu.
-2. **Askeze**: Zacnete svuj pust od alkoholu a sladkosti. Pamatujte, ze tato obet vytvari prostor pro milost.
-3. **Bratrstvo**: Oslovte sveho partnera zodpovednosti. Sdílejte sve umysly pro techto 90 dni.
+1. **Modlitba**: Strávte 20 minut v tiché modlitbě. Najděte klidné místo a buďte jednoduše přítomni Bohu.
+2. **Askeze**: Začněte svůj půst od alkoholu a sladkostí. Pamatujte, že tato oběť vytváří prostor pro milost.
+3. **Bratrstvo**: Oslovte svého partnera zodpovědnosti. Sdílejte své úmysly pro těchto 90 dní.
 
-## Pismo k rozjimani
+## Písmo k rozjímání
 
-> Hospodin je muj pastyr, nebudu mit nedostatek.
-> Doprava mi odpocinek na travnatych pastvinach,
-> vodi me ke klidnym vodam.
-> Obcerstvuje mou dusi.
-> — Zalm 23,1-3
+> Hospodin je můj pastýř, nebudu mít nedostatek.
+> Dopřává mi odpočinek na travnatých pastvinách,
+> vodí mě ke klidným vodám.
+> Občerstvuje mou duši.
+> — Žalm 23,1-3
 
-*Pamatujte: tato cesta neni o dokonalosti. Je o vernosti.*`,
+*Pamatujte: tato cesta není o dokonalosti. Je o věrnosti.*`,
 
-  'ex-d2': `# Den 2 - Disciplina modlitby
+  'ex-d2': `# Den 2 – Disciplína modlitby
 
-> "Kdyz se vsak modlis ty, vejdi do sveho pokojiku, zavri dvere a modli se ke svemu Otci, ktery je skryty." — Matous 6,6
+> "Když se však modlíš ty, vejdi do svého pokojíku, zavři dveře a modli se ke svému Otci, který je skrytý." — Matouš 6,6
 
-## Ranni rozjimani
+## Ranní rozjímání
 
-Modlitba je zakladem duchovniho zivota. Bez ni vsechny ostatni discipliny ztraceji svuj smysl. Dnes se zamerujeme na vytvoreni rytmu modlitby, ktery vas ponese v nadchazejicich tydnech.
+Modlitba je základem duchovního života. Bez ní všechny ostatní disciplíny ztrácejí svůj smysl. Dnes se zaměřujeme na vytvoření rytmu modlitby, který vás ponese v nadcházejících týdnech.
 
 ### Praxe
 
-Vyhradte si **20 minut** pro vnitrni modlitbu. Pouzijte nasledujici strukturu:
+Vyhraďte si **20 minut** pro vnitřní modlitbu. Použijte následující strukturu:
 
-1. **Priprava** (2 min): Postavte se do Bozi pritomnosti. Udelejte znameni krize.
-2. **Cteni** (3 min): Prectete dnesni urivek Pisma pomalu, dvakrat.
-3. **Rozjimani** (10 min): Premyslejte o tom, co vas oslovuje. Mluvte o tom s Bohem.
-4. **Predsevzeti** (5 min): Zvolte si jeden konkretni cin pro dnesek na zaklade sve modlitby.
+1. **Příprava** (2 min): Postavte se do Boží přítomnosti. Udělejte znamení kříže.
+2. **Čtení** (3 min): Přečtěte dnešní úryvek Písma pomalu, dvakrát.
+3. **Rozjímání** (10 min): Přemýšlejte o tom, co vás oslovuje. Mluvte o tom s Bohem.
+4. **Předsevzetí** (5 min): Zvolte si jeden konkrétní čin pro dnešek na základě své modlitby.
 
-## Pismo k rozjimani
+## Písmo k rozjímání
 
-> Ztisete se a vedzte, ze ja jsem Buh.
-> — Zalm 46,10`,
+> Ztište se a vězte, že já jsem Bůh.
+> — Žalm 46,10`,
 
-  'ex-d3': `# Den 3 - Pust a svoboda
+  'ex-d3': `# Den 3 – Půst a svoboda
 
-> "Neni prave toto posteni, jez jsem vyvolil: rozevrit okovy svevole?" — Izajas 58,6
+> "Není právě toto postění, jež jsem vyvolil: rozevřít okovy svévole?" — Izajáš 58,6
 
-## Ranni rozjimani
+## Ranní rozjímání
 
-Posteni neni trest — je to osvobozeni. Kdyz si odepirame pohodli, zjistujeme, ze nas nejhlubsi hlad neni po jidle ani piti, ale po Bohu.
+Postění není trest — je to osvobození. Když si odepíráme pohodlí, zjišťujeme, že náš nejhlubší hlad není po jídle ani pití, ale po Bohu.
 
-### Proc se postime
+### Proč se postíme
 
-Pousetni otcove chapali, ze **posteni brisi mysl** a otevira srdce. Zvazme tri rozmery:
+Pouštní otcové chápali, že **postění brousí mysl** a otevírá srdce. Zvažme tři rozměry:
 
-- **Fyzicky**: Vase telo se uci rikat "ne" okamzitemu uspokojeni
-- **Duchovni**: Kazdy zaludecni stah se stava modlitbou
-- **Spolecny**: Vase obet vas spojuje s temi, kteri hladoveji nedobrovolne
+- **Fyzický**: Vaše tělo se učí říkat "ne" okamžitému uspokojení
+- **Duchovní**: Každý žaludeční stah se stává modlitbou
+- **Společný**: Vaše oběť vás spojuje s těmi, kteří hladovějí nedobrovolně
 
-*Svoboda, kterou hledate, se nenachazi v tom, ze budete mit vice, ale v tom, ze budete potrebovat mene.*`,
+*Svoboda, kterou hledáte, se nenachází v tom, že budete mít více, ale v tom, že budete potřebovat méně.*`,
 
-  'ex-fg': `# Pruvodce: Metody modlitby
+  'ex-fg': `# Průvodce: Metody modlitby
 
-Tento pruvodce predstavuje nekolik metod modlitby pouzivanych v programu Exodus90.
+Tento průvodce představuje několik metod modlitby používaných v programu Exodus90.
 
 ## 1. Lectio Divina
 
-Ctyrstupnova metoda modlitby s Pismem:
+Čtyřstupňová metoda modlitby s Písmem:
 
-1. **Lectio** (Cteni): Prectete pasaz pomalu
-2. **Meditatio** (Rozjimani): Premyslejte o slove ci frazi, ktera vas oslovuje
-3. **Oratio** (Modlitba): Mluvte s Bohem o tom, co jste precetli
-4. **Contemplatio** (Nazirání): Odpocinete v tichosti v Bozi pritomnosti
+1. **Lectio** (Čtení): Přečtěte pasáž pomalu
+2. **Meditatio** (Rozjímání): Přemýšlejte o slově či frázi, která vás oslovuje
+3. **Oratio** (Modlitba): Mluvte s Bohem o tom, co jste přečetli
+4. **Contemplatio** (Nazírání): Odpočiňte si v tichosti v Boží přítomnosti
 
 ## 2. Examen
 
-Denni modlitba sebereflexe sv. Ignace:
+Denní modlitba sebereflexe sv. Ignáce:
 
-- **Diky** za uplynuly den
-- **Prosba o svetlo** k jasnemu videni
-- **Prehled** udalosti dne
-- **Odpoved** litosti nebo vdecnosti
-- **Predsevzeti** na zitrek`,
+- **Díky** za uplynulý den
+- **Prosba o světlo** k jasnému vidění
+- **Přehled** událostí dne
+- **Odpověď** lítostí nebo vděčností
+- **Předsevzetí** na zítřek`,
 
-  'ex-dc': `# Sablona pro tydenni kontrolu
+  'ex-dc': `# Šablona pro týdenní kontrolu
 
-Pouzijte tuto sablonu kazdy tyden k zamysleni nad svym pokrokem.
+Použijte tuto šablonu každý týden k zamyšlení nad svým pokrokem.
 
-## Prehled uplynuleho tydne
+## Přehled uplynulého týdne
 
 ### Modlitba
-- Dny, kdy jsem dokoncil cely cas modlitby: ___ / 7
+- Dny, kdy jsem dokončil celý čas modlitby: ___ / 7
 - Kvalita modlitby (1-5): ___
 
 ### Askeze
-- Dny, kdy jsem dodrzoval pust: ___ / 7
-- Nejvetsi pokuseni tohoto tydne:
+- Dny, kdy jsem dodržoval půst: ___ / 7
+- Největší pokušení tohoto týdne:
 
 ### Bratrstvo
-- Kolikrat jsem se spojil se svou skupinou: ___`,
+- Kolikrát jsem se spojil se svou skupinou: ___`,
 
-  'le-aw': `# Popelecni streda
+  'le-aw': `# Popeleční středa
 
-> "Pamatuj, ze jsi prach a v prach se obratís." — Genesis 3,19
+> "Pamatuj, že jsi prach a v prach se obrátíš." — Genesis 3,19
 
-## Zacatek postniho obdobi
+## Začátek postního období
 
-Dnes vstupujeme do svateho postniho obdobi — 40 dni modlitby, postu a almuzny, které nas pripravuji na velikonocni radost.
+Dnes vstupujeme do svatého postního období — 40 dní modlitby, postu a almužny, které nás připravují na velikonoční radost.
 
-### Tri postni praxe
+### Tři postní praxe
 
-1. **Modlitba**: Zavazat se k dennímu cteni Pisma a 15 minutam tiche modlitby
-2. **Pust**: Dnes je den postu a zdrzenlivosti. Jezte pouze jedno plne jidlo.
-3. **Almuzna**: Zvolte si charitu nebo potrebneho cloveka, ktereho budete behem postu podporovat
+1. **Modlitba**: Zavázat se k dennímu čtení Písma a 15 minutám tiché modlitby
+2. **Půst**: Dnes je den postu a zdrženlivosti. Jezte pouze jedno plné jídlo.
+3. **Almužna**: Zvolte si charitu nebo potřebného člověka, kterého budete během postu podporovat
 
-## Vecerni modlitba
+## Večerní modlitba
 
-Pane, kdyz zacinam tuto postni cestu, daruj mi milost praveho obraceni. Amen.`,
+Pane, když začínám tuto postní cestu, daruj mi milost pravého obrácení. Amen.`,
 
-  'le-d5': `# Patek prvniho tydne
+  'le-d5': `# Pátek prvního týdne
 
-> "Coz neni toto posteni, ktere jsem vyvolil: rozevrit okovy svevole?" — Izajas 58,6
+> "Což není toto postění, které jsem vyvolil: rozevřít okovy svévole?" — Izajáš 58,6
 
-## Ranni rozjimani
+## Ranní rozjímání
 
-Prvni patek v poste. Kazdy patek behem tohoto obdobi jsme volani zdrzet se masa...`,
+První pátek v postě. Každý pátek během tohoto období jsme voláni zdržet se masa...`,
 
-  'le-d20': `# Treti nedele postni
+  'le-d20': `# Třetí neděle postní
 
-> "Pane, dej mi tu vodu, abych uz nemela zizen." — Jan 4,15
+> "Pane, dej mi tu vodu, abych už neměla žízeň." — Jan 4,15
 
-## Zena u studny
+## Žena u studny
 
-Dnesni evangelium vypravi pribeh Jezise a Samaritanky u Jakubovy studny. Prisla hledat vodu; odesla, kdyz nasla pramen zive vody.
+Dnešní evangelium vypráví příběh Ježíše a Samaritánky u Jákobovy studny. Přišla hledat vodu; odešla, když našla pramen živé vody.
 
-### Tri lekce
+### Tři lekce
 
-1. **Jezis nas potkava tam, kde jsme**: Neceka, az budeme dokonali
-2. **Prava zizen je duchovni**: Nase nejhlubsi touha je po Bohu
-3. **Setkani vede k poslani**: Zena se stala evangelistkou pro cele mesto`,
+1. **Ježíš nás potkává tam, kde jsme**: Nečeká, až budeme dokonalí
+2. **Pravá žízeň je duchovní**: Naše nejhlubší touha je po Bohu
+3. **Setkání vede k poslání**: Žena se stala evangelistkou pro celé město`,
 
-  'le-fg': `# Pruvodce: Krizova cesta
+  'le-fg': `# Průvodce: Křížová cesta
 
-Krizova cesta je poboznost, ktera nasleduje Jezise na jeho ceste od odsouzeni k pohrbeni.
+Křížová cesta je pobožnost, která následuje Ježíše na jeho cestě od odsouzení k pohřbení.
 
-## Ctrnact zastaveni
+## Čtrnáct zastavení
 
-### I. zastaveni: Jezis je odsouzen k smrti
-*Klanime se ti, Kriste, a chvalime te, nebot svym svatym krizem jsi vykoupil svet.*
+### I. zastavení: Ježíš je odsouzen k smrti
+*Klaníme se ti, Kriste, a chválíme tě, neboť svým svatým křížem jsi vykoupil svět.*
 
-Pilat si myje ruce. Nevinny muz je odsouzen. Jak casto mlcime tvari v tvar nespravedlnosti?
+Pilát si myje ruce. Nevinný muž je odsouzen. Jak často mlčíme tváří v tvář nespravedlnosti?
 
-### II. zastaveni: Jezis bere na sebe kriz
-Tiha hrichu sveta spociva na jeho ramenou.
+### II. zastavení: Ježíš bere na sebe kříž
+Tíha hříchu světa spočívá na jeho ramenou.
 
-### III. zastaveni: Jezis pada poprve
-Pada, ale zase vstava. V nasich selhanich nam Kristus ukazuje, ze pad neni konec.`,
+### III. zastavení: Ježíš padá poprvé
+Padá, ale zase vstává. V našich selháních nám Kristus ukazuje, že pád není konec.`,
 
-  'ad-w1': `# Prvni tyden adventu: Nadeje
+  'ad-w1': `# První týden adventu: Naděje
 
-> "Lid, ktery chodil v temnote, uvidel velke svetlo." — Izajas 9,2
+> "Lid, který chodil v temnotě, uviděl velké světlo." — Izajáš 9,2
 
-## Zapaleni prvni svice
+## Zapálení první svíce
 
-Dnes zapalujeme prvni svici adventniho vence — svici **Nadeje**. V rostouci prosincove tme nam tento maly plamen pripomina, ze svetlo prichazi do sveta.
+Dnes zapalujeme první svíci adventního věnce — svíci **Naděje**. V rostoucí prosincové tmě nám tento malý plamen připomíná, že světlo přichází do světa.
 
-### Denni praxe
+### Denní praxe
 
-Kazdy den tento tyden:
-1. Zapalte prvni svici pri veceri
-2. Prectete si spolecne denni urivek z Pisma
-3. Pomodlete se adventni modlitbu`,
+Každý den tento týden:
+1. Zapalte první svíci při večeři
+2. Přečtěte si společně denní úryvek z Písma
+3. Pomodlete se adventní modlitbu`,
 
-  'ad-w2': `# Druhy tyden adventu: Pokoj
+  'ad-w2': `# Druhý týden adventu: Pokoj
 
-> "Nebot se nam narodi dite, syn je nam dan a na jeho ramenou spocine vladnuti. A bude nazvan: Podivuhodny radce, Mocny Buh, Vecny otec, Kníze pokoje." — Izajas 9,6
+> "Neboť se nám narodí dítě, syn je nám dán a na jeho ramenou spočine vládnutí. A bude nazván: Podivuhodný rádce, Mocný Bůh, Věčný otec, Kníže pokoje." — Izajáš 9,6
 
-## Zapaleni druhe svice
+## Zapálení druhé svíce
 
-Tento tyden pridavame druhou svici — svici **Pokoje**. Kristus neprichazi s mecem pozemske moci, ale s pokojem, ktery prevysuje vsechno chápání.`,
+Tento týden přidáváme druhou svíci — svíci **Pokoje**. Kristus nepřichází s mečem pozemské moci, ale s pokojem, který převyšuje všechno chápání.`,
 
-  'ad-fg': `# Pruvodce adventnim vencem
+  'ad-fg': `# Průvodce adventním věncem
 
-Adventni venec je krasna tradice, ktera oznacuje ctyri tydny pripravy pred Vanocemi.
+Adventní věnec je krásná tradice, která označuje čtyři týdny přípravy před Vánocemi.
 
-## Potrebny material
+## Potřebný materiál
 
-- Vecne zeleny venec
-- 3 fialove svice a 1 ruzova svice
-- 1 bila svice (volitelne, na Stedry den)
+- Věčně zelený věnec
+- 3 fialové svíce a 1 růžová svíce
+- 1 bílá svíce (volitelné, na Štědrý den)
 
-## Ctyri svice
+## Čtyři svíce
 
-| Tyden | Barva | Tema | Nazev |
+| Týden | Barva | Téma | Název |
 |-------|-------|------|-------|
-| 1 | Fialova | Nadeje | Svice proroka |
-| 2 | Fialova | Pokoj | Betlemska svice |
-| 3 | Ruzova | Radost | Pastyrska svice |
-| 4 | Fialova | Laska | Andelska svice |`,
+| 1 | Fialová | Naděje | Svíce proroka |
+| 2 | Fialová | Pokoj | Betlémská svíce |
+| 3 | Růžová | Radost | Pastýřská svíce |
+| 4 | Fialová | Láska | Andělská svíce |`,
 
-  're-t1': `# Uvodni prednaška: Nalezeni ticha
+  're-t1': `# Úvodní přednáška: Nalezení ticha
 
-> "Ztisete se a vedzte, ze ja jsem Buh." — Zalm 46,10
+> "Ztište se a vězte, že já jsem Bůh." — Žalm 46,10
 
-## Vitejte
+## Vítejte
 
-Bratri, vitejte na tomto rekolekci. Na nasledujici tri dny vystupujeme z hluku kazdodenniho zivota, abychom naslouchali Bozimu hlasu.
+Bratři, vítejte na těchto rekolekcích. Na následující tři dny vystupujeme z hluku každodenního života, abychom naslouchali Božímu hlasu.
 
-### Problem hluku
+### Problém hluku
 
-Nase zivoty jsou prosyceny hlukem:
-- Neustaly bzukot notifikaci
-- Tlak terminu a zodpovednosti
-- Vnitrni monolog uzkosti a sebekritiky
+Naše životy jsou prosyceny hlukem:
+- Neustálý bzukot notifikací
+- Tlak termínů a zodpovědností
+- Vnitřní monolog úzkosti a sebekritiky
 
-**Ticho neni neprítomnost zvuku. Je to pritomnost pozornosti.**`,
+**Ticho není nepřítomnost zvuku. Je to přítomnost pozornosti.**`,
 };
 
 const SLOVAK_CONTENT: Record<string, string> = {

--- a/scripts/azure-find-region.ts
+++ b/scripts/azure-find-region.ts
@@ -1,0 +1,73 @@
+/**
+ * Finds which Azure region a Speech key belongs to by trying the read-only
+ * voices-list endpoint in each region. Prints the region and the endpoint
+ * URL to use as AZURE_SPEECH_ENDPOINT.
+ *
+ *   pnpm tsx scripts/azure-find-region.ts   (reads AZURE_SPEECH_KEY from .env.local)
+ */
+try {
+  process.loadEnvFile?.('.env.local');
+} catch {
+  // rely on the environment
+}
+
+const REGIONS = [
+  'westeurope', 'northeurope', 'germanywestcentral', 'swedencentral', 'switzerlandnorth', 'switzerlandwest',
+  'francecentral', 'uksouth', 'ukwest', 'norwayeast', 'polandcentral', 'italynorth', 'spaincentral',
+  'eastus', 'eastus2', 'westus', 'westus2', 'westus3', 'centralus', 'northcentralus', 'southcentralus', 'westcentralus',
+  'canadacentral', 'canadaeast', 'brazilsouth', 'australiaeast', 'southeastasia', 'eastasia', 'japaneast', 'japanwest',
+  'koreacentral', 'centralindia', 'southafricanorth', 'uaenorth', 'qatarcentral',
+];
+
+const key = process.env.AZURE_SPEECH_KEY;
+if (!key) {
+  console.error('Set AZURE_SPEECH_KEY in .env.local');
+  process.exit(1);
+}
+
+async function probe(region: string): Promise<boolean> {
+  try {
+    const res = await fetch(`https://${region}.tts.speech.microsoft.com/cognitiveservices/voices/list`, {
+      headers: { 'Ocp-Apim-Subscription-Key': key! },
+      signal: AbortSignal.timeout(8000),
+    });
+    return res.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+/** The issued token carries the pricing tier; batch synthesis needs S0, not F0. */
+async function describeTier(region: string) {
+  try {
+    const res = await fetch(`https://${region}.api.cognitive.microsoft.com/sts/v1.0/issueToken`, {
+      method: 'POST',
+      headers: { 'Ocp-Apim-Subscription-Key': key! },
+    });
+    const token = await res.text();
+    const claims = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()) as Record<string, string>;
+    console.log(`tier: ${claims['product-id']}  resource: ${claims['azure-resource-id']?.split('/').pop()}`);
+    if (claims['product-id']?.endsWith('.F0')) {
+      console.log('Batch synthesis needs Standard S0. Change the pricing tier in the portal before running the probe.');
+    }
+  } catch {
+    // tier is informational only
+  }
+}
+
+async function main() {
+  const results = await Promise.all(REGIONS.map(async (region) => ({ region, ok: await probe(region) })));
+  const hits = results.filter((r) => r.ok).map((r) => r.region);
+
+  if (hits.length === 0) {
+    console.log('No region accepted the key. Check the key, or the resource may need its custom endpoint from the portal.');
+    process.exit(2);
+  }
+  for (const region of hits) {
+    console.log(`region: ${region}`);
+    console.log(`AZURE_SPEECH_ENDPOINT=https://${region}.api.cognitive.microsoft.com`);
+    await describeTier(region);
+  }
+}
+
+main();

--- a/scripts/azure-tts-probe.ts
+++ b/scripts/azure-tts-probe.ts
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { unzipSync } from 'fflate';
 import { markdownToSpeechScript } from '../src/domain/audio/audio.script';
-import { speechScriptToSsml } from '../src/domain/audio/audio.ssml';
+import { DEFAULT_PROSODY, speechScriptToSsml } from '../src/domain/audio/audio.ssml';
 
 const API_VERSION = '2024-04-01';
 const OUTPUT_FORMAT = 'audio-24khz-96kbitrate-mono-mp3';
@@ -42,7 +42,7 @@ const headers = { 'Ocp-Apim-Subscription-Key': key, 'Content-Type': 'application
 async function main() {
   const markdown = readFileSync(file!, 'utf8');
   const script = markdownToSpeechScript(markdown);
-  const ssml = speechScriptToSsml(script, { voice, locale, maxBreakMs: MAX_BREAK_MS });
+  const ssml = speechScriptToSsml(script, { voice, locale, maxBreakMs: MAX_BREAK_MS, ...DEFAULT_PROSODY });
 
   const pauses = script.segments.filter((s) => s.kind === 'pause');
   const spoken = script.segments

--- a/scripts/azure-tts-probe.ts
+++ b/scripts/azure-tts-probe.ts
@@ -10,7 +10,7 @@
  *   pnpm tsx scripts/azure-tts-probe.ts --file path/to/day.md [--voice cs-CZ-AntoninNeural] [--locale cs-CZ] [--out out.mp3]
  *
  * Env (read from .env.local if present):
- *   AZURE_SPEECH_RESOURCE  resource name, i.e. the host is {resource}.cognitiveservices.azure.com
+ *   AZURE_SPEECH_ENDPOINT  endpoint URL from the resource's "Keys and Endpoint" page
  *   AZURE_SPEECH_KEY       subscription key
  */
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -32,11 +32,11 @@ const voice = args.voice ?? 'cs-CZ-AntoninNeural';
 const locale = args.locale ?? voice.split('-').slice(0, 2).join('-');
 const out = args.out ?? file.replace(/\.md$/i, '') + '.mp3';
 
-const resource = process.env.AZURE_SPEECH_RESOURCE;
+const endpoint = process.env.AZURE_SPEECH_ENDPOINT?.replace(/\/+$/, '');
 const key = process.env.AZURE_SPEECH_KEY;
-if (!resource || !key) fail('Set AZURE_SPEECH_RESOURCE and AZURE_SPEECH_KEY');
+if (!endpoint || !key) fail('Set AZURE_SPEECH_ENDPOINT and AZURE_SPEECH_KEY');
 
-const base = `https://${resource}.cognitiveservices.azure.com/texttospeech/batchsyntheses`;
+const base = `${endpoint}/texttospeech/batchsyntheses`;
 const headers = { 'Ocp-Apim-Subscription-Key': key, 'Content-Type': 'application/json' };
 
 async function main() {

--- a/scripts/azure-tts-probe.ts
+++ b/scripts/azure-tts-probe.ts
@@ -1,0 +1,135 @@
+/**
+ * Probe for Azure Speech batch synthesis (issue #109).
+ *
+ * Reads a Markdown file, builds SSML through the same pure modules the app
+ * will use, submits a batch synthesis job, waits for it, unzips the result
+ * and writes the MP3 next to the reported duration, size and billed
+ * characters.
+ *
+ * Usage:
+ *   pnpm tsx scripts/azure-tts-probe.ts --file path/to/day.md [--voice cs-CZ-AntoninNeural] [--locale cs-CZ] [--out out.mp3]
+ *
+ * Env (read from .env.local if present):
+ *   AZURE_SPEECH_RESOURCE  resource name, i.e. the host is {resource}.cognitiveservices.azure.com
+ *   AZURE_SPEECH_KEY       subscription key
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { unzipSync } from 'fflate';
+import { markdownToSpeechScript } from '../src/domain/audio/audio.script';
+import { speechScriptToSsml } from '../src/domain/audio/audio.ssml';
+
+const API_VERSION = '2024-04-01';
+const OUTPUT_FORMAT = 'audio-24khz-96kbitrate-mono-mp3';
+const MAX_BREAK_MS = 20_000;
+
+loadEnvFile('.env.local');
+
+const args = parseArgs(process.argv.slice(2));
+const file = args.file;
+if (!file) fail('Missing --file <markdown>');
+const voice = args.voice ?? 'cs-CZ-AntoninNeural';
+const locale = args.locale ?? voice.split('-').slice(0, 2).join('-');
+const out = args.out ?? file.replace(/\.md$/i, '') + '.mp3';
+
+const resource = process.env.AZURE_SPEECH_RESOURCE;
+const key = process.env.AZURE_SPEECH_KEY;
+if (!resource || !key) fail('Set AZURE_SPEECH_RESOURCE and AZURE_SPEECH_KEY');
+
+const base = `https://${resource}.cognitiveservices.azure.com/texttospeech/batchsyntheses`;
+const headers = { 'Ocp-Apim-Subscription-Key': key, 'Content-Type': 'application/json' };
+
+async function main() {
+  const markdown = readFileSync(file!, 'utf8');
+  const script = markdownToSpeechScript(markdown);
+  const ssml = speechScriptToSsml(script, { voice, locale, maxBreakMs: MAX_BREAK_MS });
+
+  const pauses = script.segments.filter((s) => s.kind === 'pause');
+  const spoken = script.segments
+    .filter((s): s is { kind: 'text'; text: string } => s.kind === 'text')
+    .reduce((n, s) => n + s.text.length, 0);
+  console.log(`segments: ${script.segments.length}, pauses: ${pauses.length}, spoken chars: ${spoken}`);
+  console.log(`voice: ${voice}, locale: ${locale}`);
+
+  const jobId = `probe-${randomUUID()}`;
+  const created = await fetch(`${base}/${jobId}?api-version=${API_VERSION}`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({
+      inputKind: 'SSML',
+      inputs: [{ content: ssml }],
+      properties: { outputFormat: OUTPUT_FORMAT, wordBoundaryEnabled: false, sentenceBoundaryEnabled: false },
+    }),
+  });
+  if (!created.ok) fail(`create failed: ${created.status} ${await created.text()}`);
+  console.log(`job ${jobId} submitted`);
+
+  const startedAt = Date.now();
+  let job: JobResponse;
+  for (;;) {
+    await sleep(5000);
+    const res = await fetch(`${base}/${jobId}?api-version=${API_VERSION}`, { headers });
+    if (!res.ok) fail(`poll failed: ${res.status} ${await res.text()}`);
+    job = (await res.json()) as JobResponse;
+    console.log(`  ${job.status} (${Math.round((Date.now() - startedAt) / 1000)}s)`);
+    if (job.status === 'Succeeded' || job.status === 'Failed') break;
+  }
+
+  if (job.status === 'Failed') fail(`job failed: ${JSON.stringify(job.properties?.error ?? job, null, 2)}`);
+  const resultUrl = job.outputs?.result;
+  if (!resultUrl) fail('job succeeded but has no outputs.result');
+
+  const zip = await fetch(resultUrl, { headers: { 'Ocp-Apim-Subscription-Key': key! } });
+  if (!zip.ok) fail(`download failed: ${zip.status}`);
+  const entries = unzipSync(new Uint8Array(await zip.arrayBuffer()));
+  const audioName = Object.keys(entries).find((n) => /\.(mp3|wav)$/i.test(n));
+  if (!audioName) fail(`no audio in zip; entries: ${Object.keys(entries).join(', ')}`);
+  writeFileSync(out, entries[audioName!]);
+
+  const p = job.properties ?? {};
+  console.log(`\nwrote ${out} (${entries[audioName!].byteLength} bytes)`);
+  console.log(`durationInMilliseconds: ${p.durationInMilliseconds}`);
+  console.log(`sizeInBytes: ${p.sizeInBytes}`);
+  console.log(`billingDetails.neuralCharacters: ${p.billingDetails?.neuralCharacters}`);
+  console.log(`expected silence from markers: ${pauses.reduce((n, s) => n + (s.kind === 'pause' ? s.seconds : 0), 0)}s`);
+
+  await fetch(`${base}/${jobId}?api-version=${API_VERSION}`, { method: 'DELETE', headers });
+}
+
+interface JobResponse {
+  status: 'NotStarted' | 'Running' | 'Succeeded' | 'Failed';
+  outputs?: { result?: string };
+  properties?: {
+    durationInMilliseconds?: number;
+    sizeInBytes?: number;
+    billingDetails?: { neuralCharacters?: number };
+    error?: unknown;
+  };
+}
+
+function parseArgs(argv: string[]): Record<string, string | undefined> {
+  const result: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i].startsWith('--')) result[argv[i].slice(2)] = argv[i + 1] ?? '';
+  }
+  return result;
+}
+
+function loadEnvFile(path: string) {
+  try {
+    process.loadEnvFile?.(path);
+  } catch {
+    // no .env.local, rely on the environment
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+main().catch((error) => fail(String(error)));

--- a/scripts/setup-audio-s3.sh
+++ b/scripts/setup-audio-s3.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# One-time setup of the S3 bucket and IAM user for audio generation (issue #109).
+# Requires: aws CLI with admin credentials, jq. Safe to re-run.
+#
+#   scripts/setup-audio-s3.sh              # uses defaults below
+#   BUCKET=my-bucket scripts/setup-audio-s3.sh
+set -euo pipefail
+
+BUCKET="${BUCKET:-translation-helper-audios}"
+REGION="${REGION:-eu-central-1}"
+IAM_USER="${IAM_USER:-translation-helper-audios}"
+POLICY_NAME="${POLICY_NAME:-translation-helper-audios-writer}"
+ORIGINS="${ORIGINS:-https://translator.ff0000.cz,https://translator-staging.ff0000.cz,http://localhost:3000}"
+
+command -v aws >/dev/null || { echo "aws CLI not found" >&2; exit 1; }
+command -v jq  >/dev/null || { echo "jq not found" >&2; exit 1; }
+
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+echo "Account $ACCOUNT, bucket $BUCKET, region $REGION"
+
+# 1. Bucket (create if missing)
+if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  echo "Bucket exists"
+else
+  echo "Creating bucket"
+  aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+    --create-bucket-configuration LocationConstraint="$REGION" >/dev/null
+fi
+
+# 2. ACLs off, versioning off
+aws s3api put-bucket-ownership-controls --bucket "$BUCKET" \
+  --ownership-controls 'Rules=[{ObjectOwnership=BucketOwnerEnforced}]'
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+  --versioning-configuration Status=Suspended
+
+# 3. Block public access: keep ACL blocks, allow public bucket policy
+aws s3api put-public-access-block --bucket "$BUCKET" \
+  --public-access-block-configuration \
+  BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false
+
+# 4. Public read on objects only (no listing)
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy "$(jq -n --arg b "$BUCKET" '{
+  Version: "2012-10-17",
+  Statement: [{
+    Sid: "PublicReadAudio",
+    Effect: "Allow",
+    Principal: "*",
+    Action: "s3:GetObject",
+    Resource: "arn:aws:s3:::\($b)/*"
+  }]
+}')"
+
+# 5. CORS for the app origins
+aws s3api put-bucket-cors --bucket "$BUCKET" --cors-configuration "$(jq -n --arg o "$ORIGINS" '{
+  CORSRules: [{
+    AllowedOrigins: ($o | split(",")),
+    AllowedMethods: ["GET", "HEAD"],
+    AllowedHeaders: ["*"],
+    ExposeHeaders: ["Content-Length", "Content-Type"],
+    MaxAgeSeconds: 3000
+  }]
+}')"
+
+# 6. No lifecycle rules: PR links must never expire
+aws s3api delete-bucket-lifecycle --bucket "$BUCKET" 2>/dev/null || true
+
+# 7. IAM policy (write, no delete), create or update
+POLICY_ARN="arn:aws:iam::$ACCOUNT:policy/$POLICY_NAME"
+POLICY_DOC=$(jq -n --arg b "$BUCKET" '{
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Sid: "WriteAudioObjects",
+      Effect: "Allow",
+      Action: ["s3:PutObject", "s3:GetObject", "s3:HeadObject", "s3:AbortMultipartUpload"],
+      Resource: "arn:aws:s3:::\($b)/*"
+    },
+    {
+      Sid: "ProbeBucket",
+      Effect: "Allow",
+      Action: ["s3:ListBucket", "s3:GetBucketLocation"],
+      Resource: "arn:aws:s3:::\($b)"
+    }
+  ]
+}')
+if aws iam get-policy --policy-arn "$POLICY_ARN" >/dev/null 2>&1; then
+  echo "Policy exists, updating"
+  # IAM keeps max 5 versions; drop the oldest non-default if full
+  for v in $(aws iam list-policy-versions --policy-arn "$POLICY_ARN" \
+      --query 'Versions[?IsDefaultVersion==`false`].VersionId' --output text); do
+    aws iam delete-policy-version --policy-arn "$POLICY_ARN" --version-id "$v"
+  done
+  aws iam create-policy-version --policy-arn "$POLICY_ARN" \
+    --policy-document "$POLICY_DOC" --set-as-default >/dev/null
+else
+  echo "Creating policy"
+  aws iam create-policy --policy-name "$POLICY_NAME" --policy-document "$POLICY_DOC" >/dev/null
+fi
+
+# 8. IAM user
+if aws iam get-user --user-name "$IAM_USER" >/dev/null 2>&1; then
+  echo "User exists"
+else
+  echo "Creating user"
+  aws iam create-user --user-name "$IAM_USER" >/dev/null
+fi
+aws iam attach-user-policy --user-name "$IAM_USER" --policy-arn "$POLICY_ARN"
+
+# 9. Access key (only if the user has none yet; keys can't be re-read later)
+EXISTING=$(aws iam list-access-keys --user-name "$IAM_USER" --query 'AccessKeyMetadata[].AccessKeyId' --output text)
+if [ -n "$EXISTING" ]; then
+  echo
+  echo "User already has access key(s): $EXISTING"
+  echo "Secrets cannot be shown again. To rotate:"
+  echo "  aws iam delete-access-key --user-name $IAM_USER --access-key-id <id>"
+  echo "then re-run this script."
+  exit 0
+fi
+
+KEY=$(aws iam create-access-key --user-name "$IAM_USER" --output json)
+
+echo
+echo "# Paste into .env.local and Coolify:"
+echo "AUDIO_S3_ENDPOINT=https://s3.$REGION.amazonaws.com"
+echo "AUDIO_S3_REGION=$REGION"
+echo "AUDIO_S3_BUCKET=$BUCKET"
+echo "AUDIO_S3_ACCESS_KEY_ID=$(jq -r .AccessKey.AccessKeyId <<<"$KEY")"
+echo "AUDIO_S3_SECRET_ACCESS_KEY=$(jq -r .AccessKey.SecretAccessKey <<<"$KEY")"
+echo "AUDIO_S3_PUBLIC_BASE_URL=https://$BUCKET.s3.$REGION.amazonaws.com"

--- a/src/app/documents/[id]/review/page.client.tsx
+++ b/src/app/documents/[id]/review/page.client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AudioStatus } from '@/components/audio-status';
 import { GitHubStatus } from '@/components/github-status';
 import { StatusDropdown } from '@/components/status-dropdown';
 import { Button } from '@/components/ui/button';
@@ -78,10 +79,13 @@ export default function ReviewClient({
       }}
       activityLogs={initialTargetVersion.activityLogs ?? []}
       extraDetails={
-        <GitHubStatus
-          documentVersionId={initialTargetVersion.id}
-          isDeployed={initialTargetVersion.status === DocumentStatus.DEPLOYED}
-        />
+        <>
+          <AudioStatus documentVersionId={initialTargetVersion.id} />
+          <GitHubStatus
+            documentVersionId={initialTargetVersion.id}
+            isDeployed={initialTargetVersion.status === DocumentStatus.DEPLOYED}
+          />
+        </>
       }
     />
   );

--- a/src/components/activity-log.tsx
+++ b/src/components/activity-log.tsx
@@ -21,6 +21,7 @@ import {
   Send,
   Trash2,
   UserPlus,
+  Volume2,
   XCircle,
 } from 'lucide-react';
 import { type LucideIcon } from 'lucide-react';
@@ -61,6 +62,9 @@ const ACTION_MAP: Record<string, ActionConfig> = {
   status_updated: { label: 'Changed status', icon: ArrowRightLeft, colorClass: 'text-gray-500' },
   github_deployed: { label: 'Deployed to GitHub', icon: Github, colorClass: 'text-violet-500' },
   github_deploy_failed: { label: 'GitHub deploy failed', icon: AlertTriangle, colorClass: 'text-red-500' },
+  audio_generation_started: { label: 'Started audio generation', icon: Volume2, colorClass: 'text-blue-500' },
+  audio_generated: { label: 'Audio generated', icon: Volume2, colorClass: 'text-green-500' },
+  audio_generation_failed: { label: 'Audio generation failed', icon: AlertTriangle, colorClass: 'text-red-500' },
   applied_suggestion: { label: 'Applied suggestion', icon: CheckCheck, colorClass: 'text-green-500' },
   reopened_suggestion: { label: 'Reopened suggestion', icon: RotateCcw, colorClass: 'text-orange-500' },
   dismissed_suggestion: { label: 'Dismissed suggestion', icon: XCircle, colorClass: 'text-gray-500' },
@@ -119,7 +123,10 @@ function getDetailText(action: string, details: Record<string, any> | null): str
     case 'created_translation':
     case 'assigned_translation':
       return details.language || null;
+    case 'audio_generation_started':
+      return details.voice || null;
     case 'github_deploy_failed':
+    case 'audio_generation_failed':
       return details.error ? (details.error.length > 60 ? details.error.slice(0, 60) + '...' : details.error) : null;
     case 'created_suggestion':
     case 'deleted_suggestion':

--- a/src/components/audio-status.tsx
+++ b/src/components/audio-status.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { AlertCircle, Copy, Download, Loader2, Volume2 } from 'lucide-react';
+import { advanceAudioJobAction, getLatestAudioFileAction } from '@/domain/audio/audio.actions';
+import type { AudioFileView } from '@/domain/audio/audio.types';
+import { toast } from 'sonner';
+
+interface AudioStatusProps {
+  documentVersionId: string;
+}
+
+const POLL_INTERVAL_MS = 5000;
+
+const isInFlight = (audio: AudioFileView | null) => audio?.status === 'PENDING' || audio?.status === 'PROCESSING';
+
+/**
+ * Sidebar card for the generated audio of a document version. Renders
+ * nothing until a generation exists; polls while one is in flight.
+ */
+export function AudioStatus({ documentVersionId }: AudioStatusProps) {
+  const [audio, setAudio] = useState<AudioFileView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setAudio(await getLatestAudioFileAction(documentVersionId));
+    } catch (error) {
+      console.error('[AudioStatus] Error loading audio:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [documentVersionId]);
+
+  useEffect(() => {
+    setLoading(true);
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!isInFlight(audio)) return;
+    const id = audio!.id;
+    timer.current = setTimeout(async () => {
+      try {
+        const next = await advanceAudioJobAction(id);
+        if (next) setAudio(next);
+      } catch (error) {
+        console.error('[AudioStatus] Error advancing job:', error);
+      }
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [audio]);
+
+  const handleCopyUrl = async () => {
+    if (!audio?.url) return;
+    try {
+      await navigator.clipboard.writeText(audio.url);
+      toast.success('Audio URL copied');
+    } catch {
+      toast.error('Could not copy the URL');
+    }
+  };
+
+  if (loading || !audio) return null;
+
+  return (
+    <Card className="mt-4 p-4">
+      <h3 className="text-sm font-semibold mb-2 flex items-center gap-2">
+        <Volume2 className="h-5 w-5" />
+        Audio
+      </h3>
+
+      {isInFlight(audio) && (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Generating audio with {audio.voice}...
+        </div>
+      )}
+
+      {audio.status === 'FAILED' && (
+        <div className="flex items-start gap-2 text-red-600">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">Audio generation failed</p>
+            <p className="text-sm break-words">{audio.errorMessage ?? 'Unknown error'}</p>
+          </div>
+        </div>
+      )}
+
+      {audio.status === 'READY' && audio.url && (
+        <div className="space-y-3">
+          <audio controls preload="none" src={audio.url} className="w-full" />
+          <div className="text-xs text-gray-500">
+            {audio.voice}
+            {audio.durationMs ? ` · ${formatDuration(audio.durationMs)}` : ''}
+            {audio.sizeBytes ? ` · ${(audio.sizeBytes / 1024 / 1024).toFixed(1)} MB` : ''}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <a href={audio.url} download target="_blank" rel="noopener noreferrer">
+                <Download className="h-3 w-3 mr-1" />
+                Download
+              </a>
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleCopyUrl}>
+              <Copy className="h-3 w-3 mr-1" />
+              Copy URL
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function formatDuration(ms: number): string {
+  const total = Math.round(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}

--- a/src/domain/audio/audio.actions.ts
+++ b/src/domain/audio/audio.actions.ts
@@ -1,0 +1,36 @@
+'use server';
+
+import { authorize } from '@/lib/authorize';
+import type { AudioFile } from '@prisma/client';
+import { getLatestAudioFileForVersion } from './audio.repository';
+import { advanceJob } from './audio.service';
+import type { AudioFileView } from './audio.types';
+
+export async function getLatestAudioFileAction(documentVersionId: string): Promise<AudioFileView | null> {
+  await authorize('authenticated');
+  const audioFile = await getLatestAudioFileForVersion(documentVersionId);
+  return audioFile ? toView(audioFile) : null;
+}
+
+/** Polled by the review page while a generation is pending. */
+export async function advanceAudioJobAction(audioFileId: string): Promise<AudioFileView | null> {
+  await authorize('authenticated');
+  const audioFile = await advanceJob(audioFileId);
+  return audioFile ? toView(audioFile) : null;
+}
+
+function toView(audioFile: AudioFile): AudioFileView {
+  return {
+    id: audioFile.id,
+    status: audioFile.status,
+    provider: audioFile.provider,
+    voice: audioFile.voice,
+    sourceVersion: audioFile.sourceVersion,
+    url: audioFile.url,
+    durationMs: audioFile.durationMs,
+    sizeBytes: audioFile.sizeBytes,
+    errorMessage: audioFile.errorMessage,
+    createdAt: audioFile.createdAt.toISOString(),
+    updatedAt: audioFile.updatedAt.toISOString(),
+  };
+}

--- a/src/domain/audio/audio.paths.test.ts
+++ b/src/domain/audio/audio.paths.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DocumentType } from '@prisma/client';
+import { resolveAudioObjectKey } from './audio.paths';
+
+const base = { languageCode: 'cs', identifier: 'summer_2025', slug: 'some-doc', audioFileId: 'abc-123' };
+
+test('DAY audio key mirrors the repo path under audio/ with the record id as filename', () => {
+  const key = resolveAudioObjectKey({ ...base, documentType: DocumentType.DAY, originalFilename: '1.md' });
+  assert.equal(key, 'audio/cs/exercises/summer_2025/days/1/abc-123.mp3');
+});
+
+test('DAILY_CONTENT audio key keeps the year/month folders', () => {
+  const key = resolveAudioObjectKey({
+    ...base,
+    documentType: DocumentType.DAILY_CONTENT,
+    originalFilename: '20260201-5.md',
+  });
+  assert.equal(key, 'audio/cs/daily_content/2026/02/20260201-5/abc-123.mp3');
+});
+
+test('a regeneration with a different record id produces a different key', () => {
+  const a = resolveAudioObjectKey({ ...base, documentType: DocumentType.DAY, originalFilename: '1.md' });
+  const b = resolveAudioObjectKey({ ...base, documentType: DocumentType.DAY, originalFilename: '1.md', audioFileId: 'def' });
+  assert.notEqual(a, b);
+});
+
+test('errors from the repo path resolver propagate (no filename for MEETING)', () => {
+  assert.throws(() => resolveAudioObjectKey({ ...base, documentType: DocumentType.MEETING, originalFilename: null }));
+});

--- a/src/domain/audio/audio.paths.ts
+++ b/src/domain/audio/audio.paths.ts
@@ -1,0 +1,22 @@
+import { resolveFilePath } from '../github/github.paths';
+import type { FilePathParams } from '../github/github.types';
+import { AUDIO_FILE_EXTENSION } from './audio.types';
+
+const REPO_PREFIX = 'translations/';
+const AUDIO_PREFIX = 'audio/';
+
+/**
+ * Object key for a generated audio file. Mirrors the repo path of the
+ * document so files are easy to find by hand, swaps the extension for the
+ * audio format, and nests the audio record id so a regeneration writes a new
+ * object instead of overwriting one a copied URL points at.
+ *
+ *   translations/cs/exercises/summer_2025/days/1.md
+ *   -> audio/cs/exercises/summer_2025/days/1/{audioFileId}.mp3
+ */
+export function resolveAudioObjectKey(params: FilePathParams & { audioFileId: string }): string {
+  const repoPath = resolveFilePath(params);
+  const withoutPrefix = repoPath.startsWith(REPO_PREFIX) ? repoPath.slice(REPO_PREFIX.length) : repoPath;
+  const withoutExtension = withoutPrefix.replace(/\.[^./]+$/, '');
+  return `${AUDIO_PREFIX}${withoutExtension}/${params.audioFileId}.${AUDIO_FILE_EXTENSION}`;
+}

--- a/src/domain/audio/audio.repository.ts
+++ b/src/domain/audio/audio.repository.ts
@@ -1,0 +1,63 @@
+import prisma from '@/lib/db';
+import { AudioProvider, AudioStatus } from '@prisma/client';
+
+export async function createAudioFile(data: {
+  documentVersionId: string;
+  provider: AudioProvider;
+  voice: string;
+  sourceVersion: number;
+  triggeredByUserId: string | null;
+}) {
+  return prisma.audioFile.create({ data });
+}
+
+export async function getAudioFileById(id: string) {
+  return prisma.audioFile.findUnique({ where: { id } });
+}
+
+export async function getLatestAudioFileForVersion(documentVersionId: string) {
+  return prisma.audioFile.findFirst({
+    where: { documentVersionId },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function setAudioFileJob(id: string, providerJobId: string) {
+  return prisma.audioFile.update({ where: { id }, data: { providerJobId } });
+}
+
+/**
+ * Moves a PENDING record to PROCESSING and reports whether this caller won.
+ * Two concurrent callers both try; only one sees count === 1.
+ */
+export async function claimAudioFileForProcessing(id: string): Promise<boolean> {
+  const { count } = await prisma.audioFile.updateMany({
+    where: { id, status: AudioStatus.PENDING },
+    data: { status: AudioStatus.PROCESSING },
+  });
+  return count === 1;
+}
+
+export async function releaseAudioFileToPending(id: string) {
+  return prisma.audioFile.updateMany({
+    where: { id, status: AudioStatus.PROCESSING },
+    data: { status: AudioStatus.PENDING },
+  });
+}
+
+export async function markAudioFileReady(
+  id: string,
+  data: { objectKey: string; url: string; durationMs?: number; sizeBytes?: number; billedCharacters?: number },
+) {
+  return prisma.audioFile.update({
+    where: { id },
+    data: { status: AudioStatus.READY, errorMessage: null, ...data },
+  });
+}
+
+export async function markAudioFileFailed(id: string, errorMessage: string) {
+  return prisma.audioFile.update({
+    where: { id },
+    data: { status: AudioStatus.FAILED, errorMessage: errorMessage.slice(0, 2000) },
+  });
+}

--- a/src/domain/audio/audio.service.ts
+++ b/src/domain/audio/audio.service.ts
@@ -134,7 +134,7 @@ async function complete(
     languageCode: string;
   },
 ): Promise<AudioFile> {
-  const objectKey = resolveAudioObjectKey({
+  const relativeKey = resolveAudioObjectKey({
     documentType: ctx.document.type!,
     languageCode: ctx.languageCode,
     identifier: ctx.document.sourceProject?.identifier ?? 'unknown',
@@ -142,7 +142,11 @@ async function complete(
     slug: ctx.document.slug,
     audioFileId: audioFile.id,
   });
-  const { url } = await putObject({ key: objectKey, body: result.audio, contentType: AUDIO_CONTENT_TYPE });
+  const { key: objectKey, url } = await putObject({
+    key: relativeKey,
+    body: result.audio,
+    contentType: AUDIO_CONTENT_TYPE,
+  });
 
   const updated = await markAudioFileReady(audioFile.id, {
     objectKey,

--- a/src/domain/audio/audio.service.ts
+++ b/src/domain/audio/audio.service.ts
@@ -1,0 +1,208 @@
+import prisma from '@/lib/db';
+import { isAudioStorageConfigured } from '@/lib/audio-storage-config';
+import { putObject } from '@/lib/object-storage';
+import { AudioStatus, type AudioFile } from '@prisma/client';
+import { createActivityLog } from '../activity-log/activity-log.repository';
+import { resolveAudioObjectKey } from './audio.paths';
+import {
+  claimAudioFileForProcessing,
+  createAudioFile,
+  getAudioFileById,
+  markAudioFileFailed,
+  markAudioFileReady,
+  releaseAudioFileToPending,
+  setAudioFileJob,
+} from './audio.repository';
+import { markdownToSpeechScript } from './audio.script';
+import { speechScriptToSsml } from './audio.ssml';
+import { AUDIO_CONTENT_TYPE, type AudioGenerationOutcome, type AudioSkipReason } from './audio.types';
+import { getSpeechProvider } from './providers/speech-provider';
+import type { SynthesisResult } from './providers/speech-provider';
+
+const LOG_PREFIX = '[Audio]';
+
+/**
+ * Creates an audio record for a document version and hands the synthesis to
+ * the language's provider. Never throws: configuration gaps come back as
+ * `skipped`, everything else as `failed`, so a status transition is never
+ * blocked by audio.
+ */
+export async function startGeneration(documentVersionId: string, userId: string): Promise<AudioGenerationOutcome> {
+  const version = await prisma.documentVersion.findUnique({
+    where: { id: documentVersionId },
+    include: { document: { include: { sourceProject: true } }, language: true },
+  });
+  if (!version) return { status: 'failed', error: `Document version not found: ${documentVersionId}` };
+
+  const skip = eligibilitySkipReason(version);
+  if (skip) {
+    console.log(`${LOG_PREFIX} skipping generation for ${documentVersionId}: ${skip}`);
+    return { status: 'skipped', reason: skip };
+  }
+
+  const { language, document } = version;
+  const provider = getSpeechProvider(language.audioProvider!);
+  const voice = language.audioVoice!;
+
+  const audioFile = await createAudioFile({
+    documentVersionId,
+    provider: provider.id,
+    voice,
+    sourceVersion: version.version,
+    triggeredByUserId: userId,
+  });
+  await createActivityLog({
+    documentVersionId,
+    userId,
+    action: 'audio_generation_started',
+    details: { audioFileId: audioFile.id, voice },
+  });
+
+  try {
+    const script = markdownToSpeechScript(version.content);
+    if (!script.segments.some((s) => s.kind === 'text')) {
+      throw new Error('The document has no readable text after stripping Markdown');
+    }
+    const ssml = speechScriptToSsml(script, {
+      voice,
+      locale: localeFromVoice(voice),
+      maxBreakMs: provider.maxBreakMs,
+    });
+
+    const outcome = await provider.submit({ jobId: jobIdFor(audioFile.id), ssml });
+    if (outcome.kind === 'result') {
+      // Synchronous provider: finish in the same call.
+      await claimAudioFileForProcessing(audioFile.id);
+      await complete(audioFile, outcome.result, { document, languageCode: language.code });
+    } else {
+      await setAudioFileJob(audioFile.id, outcome.jobId);
+    }
+    return { status: 'success', audioFileId: audioFile.id };
+  } catch (error: unknown) {
+    const message = errorMessage(error);
+    console.error(`${LOG_PREFIX} generation failed for ${documentVersionId}:`, message);
+    await fail(audioFile, message);
+    return { status: 'failed', error: message };
+  }
+}
+
+/**
+ * Moves one record forward: polls the provider, and on success uploads the
+ * audio and marks the record READY. Idempotent and safe to call from several
+ * places at once; only the caller that claims the PENDING row does the work.
+ */
+export async function advanceJob(audioFileId: string): Promise<AudioFile | null> {
+  const audioFile = await getAudioFileById(audioFileId);
+  if (!audioFile) return null;
+  if (audioFile.status === AudioStatus.READY || audioFile.status === AudioStatus.FAILED) return audioFile;
+  if (!audioFile.providerJobId) {
+    return markAudioFileFailed(audioFileId, 'No provider job was recorded for this generation');
+  }
+
+  const claimed = await claimAudioFileForProcessing(audioFileId);
+  if (!claimed) return audioFile; // someone else is on it
+
+  try {
+    const outcome = await getSpeechProvider(audioFile.provider).poll(audioFile.providerJobId);
+    if (outcome.kind === 'running') {
+      await releaseAudioFileToPending(audioFileId);
+      return getAudioFileById(audioFileId);
+    }
+    if (outcome.kind === 'failed') {
+      return fail(audioFile, outcome.message);
+    }
+
+    const version = await prisma.documentVersion.findUnique({
+      where: { id: audioFile.documentVersionId },
+      include: { document: { include: { sourceProject: true } }, language: true },
+    });
+    if (!version) throw new Error('Document version disappeared while audio was generating');
+    return complete(audioFile, outcome.result, { document: version.document, languageCode: version.language.code });
+  } catch (error: unknown) {
+    const message = errorMessage(error);
+    console.error(`${LOG_PREFIX} advancing ${audioFileId} failed:`, message);
+    return fail(audioFile, message);
+  }
+}
+
+async function complete(
+  audioFile: AudioFile,
+  result: SynthesisResult,
+  ctx: {
+    document: { type: import('@prisma/client').DocumentType | null; originalFilename: string | null; slug: string; sourceProject: { identifier: string | null } | null };
+    languageCode: string;
+  },
+): Promise<AudioFile> {
+  const objectKey = resolveAudioObjectKey({
+    documentType: ctx.document.type!,
+    languageCode: ctx.languageCode,
+    identifier: ctx.document.sourceProject?.identifier ?? 'unknown',
+    originalFilename: ctx.document.originalFilename,
+    slug: ctx.document.slug,
+    audioFileId: audioFile.id,
+  });
+  const { url } = await putObject({ key: objectKey, body: result.audio, contentType: AUDIO_CONTENT_TYPE });
+
+  const updated = await markAudioFileReady(audioFile.id, {
+    objectKey,
+    url,
+    durationMs: result.durationMs,
+    sizeBytes: result.sizeBytes,
+    billedCharacters: result.billedCharacters,
+  });
+  if (audioFile.triggeredByUserId) {
+    await createActivityLog({
+      documentVersionId: audioFile.documentVersionId,
+      userId: audioFile.triggeredByUserId,
+      action: 'audio_generated',
+      details: { audioFileId: audioFile.id, durationMs: result.durationMs ?? null },
+    });
+  }
+  console.log(`${LOG_PREFIX} ${audioFile.id} ready at ${url}`);
+  return updated;
+}
+
+async function fail(audioFile: AudioFile, message: string): Promise<AudioFile> {
+  const updated = await markAudioFileFailed(audioFile.id, message);
+  if (audioFile.triggeredByUserId) {
+    await createActivityLog({
+      documentVersionId: audioFile.documentVersionId,
+      userId: audioFile.triggeredByUserId,
+      action: 'audio_generation_failed',
+      details: { audioFileId: audioFile.id, error: message },
+    });
+  }
+  return updated;
+}
+
+type VersionForEligibility = {
+  language: { audioProvider: import('@prisma/client').AudioProvider | null; audioVoice: string | null };
+  document: {
+    type: import('@prisma/client').DocumentType | null;
+    sourceProject: { audioDocumentTypes: import('@prisma/client').DocumentType[] } | null;
+  };
+};
+
+function eligibilitySkipReason(version: VersionForEligibility): AudioSkipReason | null {
+  const { language, document } = version;
+  if (!language.audioProvider || !language.audioVoice) return 'no_voice_for_language';
+  if (!document.type) return 'document_type_missing';
+  if (!document.sourceProject?.audioDocumentTypes.includes(document.type)) return 'document_type_not_enabled';
+  if (!isAudioStorageConfigured()) return 'storage_not_configured';
+  if (!getSpeechProvider(language.audioProvider).isConfigured()) return 'provider_not_configured';
+  return null;
+}
+
+/** `cs-CZ-AntoninNeural` -> `cs-CZ`. Provider voice ids lead with their locale. */
+export function localeFromVoice(voice: string): string {
+  return voice.split('-').slice(0, 2).join('-');
+}
+
+/** Azure allows 3-64 chars of [A-Za-z0-9-_.]; a UUID with a prefix fits. */
+function jobIdFor(audioFileId: string): string {
+  return `th-${audioFileId}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/domain/audio/audio.service.ts
+++ b/src/domain/audio/audio.service.ts
@@ -14,7 +14,7 @@ import {
   setAudioFileJob,
 } from './audio.repository';
 import { markdownToSpeechScript } from './audio.script';
-import { speechScriptToSsml } from './audio.ssml';
+import { DEFAULT_PROSODY, speechScriptToSsml } from './audio.ssml';
 import { AUDIO_CONTENT_TYPE, type AudioGenerationOutcome, type AudioSkipReason } from './audio.types';
 import { getSpeechProvider } from './providers/speech-provider';
 import type { SynthesisResult } from './providers/speech-provider';
@@ -67,6 +67,7 @@ export async function startGeneration(documentVersionId: string, userId: string)
       voice,
       locale: localeFromVoice(voice),
       maxBreakMs: provider.maxBreakMs,
+      ...DEFAULT_PROSODY,
     });
 
     const outcome = await provider.submit({ jobId: jobIdFor(audioFile.id), ssml });

--- a/src/domain/audio/audio.ssml.test.ts
+++ b/src/domain/audio/audio.ssml.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { escapeXml, renderPause, speechScriptToSsml } from './audio.ssml';
+import { DEFAULT_PROSODY, escapeXml, renderPause, speechScriptToSsml } from './audio.ssml';
 
 const opts = { voice: 'cs-CZ-AntoninNeural', locale: 'cs-CZ', maxBreakMs: 20_000 };
 
@@ -60,4 +60,26 @@ test('an empty script still produces well-formed SSML', () => {
 
 test('rejects a non-positive break ceiling', () => {
   assert.throws(() => speechScriptToSsml({ segments: [] }, { ...opts, maxBreakMs: 0 }));
+});
+
+test('rate and pitch wrap the whole body in one prosody element', () => {
+  const ssml = speechScriptToSsml(
+    { segments: [{ kind: 'text', text: 'One.' }, { kind: 'pause', seconds: 2 }, { kind: 'text', text: 'Two.' }] },
+    { ...opts, rate: '0.8', pitch: '-6%' },
+  );
+  assert.ok(ssml.includes('<voice name="cs-CZ-AntoninNeural"><prosody rate="0.8" pitch="-6%"><p>One.</p><break time="2000ms"/><p>Two.</p></prosody></voice>'));
+});
+
+test('no prosody element is emitted when neither rate nor pitch is given', () => {
+  const ssml = speechScriptToSsml({ segments: [{ kind: 'text', text: 'One.' }] }, opts);
+  assert.ok(!ssml.includes('<prosody'));
+});
+
+test('rate alone yields a prosody element with only a rate attribute', () => {
+  const ssml = speechScriptToSsml({ segments: [{ kind: 'text', text: 'One.' }] }, { ...opts, rate: '-20%' });
+  assert.ok(ssml.includes('<prosody rate="-20%"><p>One.</p></prosody>'));
+});
+
+test('default prosody is the listening-test pick', () => {
+  assert.deepEqual(DEFAULT_PROSODY, { rate: '0.8', pitch: '-6%' });
 });

--- a/src/domain/audio/audio.ssml.ts
+++ b/src/domain/audio/audio.ssml.ts
@@ -15,7 +15,18 @@ export interface SsmlOptions {
   locale: string;
   /** Longest single <break> the provider honours, in milliseconds. */
   maxBreakMs: number;
+  /** Speaking rate as a factor (`0.8` = 20% slower) or a percentage (`-20%`). Omit for the voice default. */
+  rate?: string;
+  /** Pitch as a percentage (`-6%`). Omit for the voice default. */
+  pitch?: string;
 }
+
+/**
+ * Chosen by ear on real Czech content (Antonín, 2026-08-25): the untuned voice
+ * reads too briskly for a reflection. Rate 0.8 with a slightly lower pitch was
+ * the pick; volume is left alone so listeners control it on their device.
+ */
+export const DEFAULT_PROSODY = { rate: '0.8', pitch: '-6%' } as const;
 
 export function speechScriptToSsml(script: SpeechScript, options: SsmlOptions): string {
   if (!(options.maxBreakMs > 0)) {
@@ -28,9 +39,14 @@ export function speechScriptToSsml(script: SpeechScript, options: SsmlOptions): 
 
   return (
     `<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="${escapeXml(options.locale)}">` +
-    `<voice name="${escapeXml(options.voice)}">${body}</voice>` +
+    `<voice name="${escapeXml(options.voice)}">${wrapProsody(body, options)}</voice>` +
     `</speak>`
   );
+}
+
+function wrapProsody(body: string, { rate, pitch }: SsmlOptions): string {
+  const attrs = [rate ? ` rate="${escapeXml(rate)}"` : '', pitch ? ` pitch="${escapeXml(pitch)}"` : ''].join('');
+  return attrs ? `<prosody${attrs}>${body}</prosody>` : body;
 }
 
 /** Splits a pause into as many <break> elements as the ceiling requires. */

--- a/src/domain/audio/audio.types.ts
+++ b/src/domain/audio/audio.types.ts
@@ -1,0 +1,42 @@
+import type { AudioProvider, AudioStatus } from '@prisma/client';
+
+export type { AudioProvider, AudioStatus };
+
+/** What the caller of a status transition learns about the audio side effect. */
+export type AudioGenerationOutcome =
+  | { status: 'success'; audioFileId: string }
+  | { status: 'skipped'; reason: AudioSkipReason }
+  | { status: 'failed'; error: string };
+
+export type AudioSkipReason =
+  | 'storage_not_configured'
+  | 'provider_not_configured'
+  | 'no_voice_for_language'
+  | 'document_type_not_enabled'
+  | 'document_type_missing';
+
+export const AUDIO_SKIP_MESSAGES: Record<AudioSkipReason, string> = {
+  storage_not_configured: 'Audio storage is not configured',
+  provider_not_configured: 'The speech provider is not configured',
+  no_voice_for_language: 'This language has no voice configured',
+  document_type_not_enabled: 'Audio is not enabled for this document type',
+  document_type_missing: 'The document has no type set',
+};
+
+export const AUDIO_CONTENT_TYPE = 'audio/mpeg';
+export const AUDIO_FILE_EXTENSION = 'mp3';
+
+/** Shape handed to the client card; dates serialised by the server action. */
+export interface AudioFileView {
+  id: string;
+  status: AudioStatus;
+  provider: AudioProvider;
+  voice: string;
+  sourceVersion: number;
+  url: string | null;
+  durationMs: number | null;
+  sizeBytes: number | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/domain/audio/providers/azure-speech.ts
+++ b/src/domain/audio/providers/azure-speech.ts
@@ -1,0 +1,116 @@
+import { AudioProvider } from '@prisma/client';
+import { unzipSync } from 'fflate';
+import { getAzureSpeechConfig, isAzureSpeechConfigured } from '@/lib/azure-speech-config';
+import type { PollOutcome, SpeechProvider, SubmitOutcome, SynthesisRequest, SynthesisResult } from './speech-provider';
+
+/**
+ * Azure Speech batch synthesis. Chosen over the real-time endpoint because
+ * that one silently truncates at ten minutes of audio (see #107).
+ *
+ * The result of a job is a ZIP containing the audio plus summary/debug
+ * files; this module unpacks it so nothing outside knows.
+ */
+
+const API_VERSION = '2024-04-01';
+const OUTPUT_FORMAT = 'audio-24khz-96kbitrate-mono-mp3';
+const LOG_PREFIX = '[AzureSpeech]';
+
+interface BatchJob {
+  status: 'NotStarted' | 'Running' | 'Succeeded' | 'Failed';
+  outputs?: { result?: string };
+  properties?: {
+    durationInMilliseconds?: number;
+    sizeInBytes?: number;
+    billingDetails?: { neuralCharacters?: number };
+    error?: { code?: string; message?: string };
+  };
+}
+
+function baseUrl() {
+  return `https://${getAzureSpeechConfig().resource}.cognitiveservices.azure.com/texttospeech/batchsyntheses`;
+}
+
+function authHeaders(): Record<string, string> {
+  return { 'Ocp-Apim-Subscription-Key': getAzureSpeechConfig().key };
+}
+
+export const azureSpeechProvider: SpeechProvider = {
+  id: AudioProvider.AZURE_SPEECH,
+  maxBreakMs: 20_000,
+  isConfigured: isAzureSpeechConfigured,
+
+  async submit(request: SynthesisRequest): Promise<SubmitOutcome> {
+    const res = await fetch(`${baseUrl()}/${request.jobId}?api-version=${API_VERSION}`, {
+      method: 'PUT',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        inputKind: 'SSML',
+        inputs: [{ content: request.ssml }],
+        properties: { outputFormat: OUTPUT_FORMAT, wordBoundaryEnabled: false, sentenceBoundaryEnabled: false },
+      }),
+    });
+
+    // 409: a job with this id already exists, which is the retry case the
+    // caller-chosen id is there for. Poll it instead of creating a duplicate.
+    if (res.status === 409) {
+      console.log(`${LOG_PREFIX} job ${request.jobId} already exists, reusing`);
+      return { kind: 'job', jobId: request.jobId };
+    }
+    if (!res.ok) {
+      throw new Error(`Azure batch synthesis create failed (${res.status}): ${await safeText(res)}`);
+    }
+    return { kind: 'job', jobId: request.jobId };
+  },
+
+  async poll(jobId: string): Promise<PollOutcome> {
+    const res = await fetch(`${baseUrl()}/${jobId}?api-version=${API_VERSION}`, { headers: authHeaders() });
+    if (!res.ok) {
+      throw new Error(`Azure batch synthesis poll failed (${res.status}): ${await safeText(res)}`);
+    }
+    const job = (await res.json()) as BatchJob;
+
+    if (job.status === 'Failed') {
+      const error = job.properties?.error;
+      return { kind: 'failed', message: error?.message ?? error?.code ?? 'Azure reported the job as failed' };
+    }
+    if (job.status !== 'Succeeded') return { kind: 'running' };
+
+    const resultUrl = job.outputs?.result;
+    if (!resultUrl) return { kind: 'failed', message: 'Azure job succeeded but returned no result file' };
+
+    const result = await downloadResult(resultUrl, job);
+    // Best effort: the result is ours now, Azure's copy can go.
+    void fetch(`${baseUrl()}/${jobId}?api-version=${API_VERSION}`, { method: 'DELETE', headers: authHeaders() }).catch(
+      () => undefined,
+    );
+    return { kind: 'succeeded', result };
+  },
+};
+
+async function downloadResult(resultUrl: string, job: BatchJob): Promise<SynthesisResult> {
+  const res = await fetch(resultUrl, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`Azure result download failed (${res.status})`);
+
+  const entries = unzipSync(new Uint8Array(await res.arrayBuffer()));
+  const audioName = Object.keys(entries).find((name) => /\.mp3$/i.test(name));
+  if (!audioName) {
+    throw new Error(`Azure result ZIP contains no MP3 (entries: ${Object.keys(entries).join(', ')})`);
+  }
+
+  const props = job.properties ?? {};
+  return {
+    audio: entries[audioName],
+    contentType: 'audio/mpeg',
+    durationMs: props.durationInMilliseconds,
+    sizeBytes: props.sizeInBytes ?? entries[audioName].byteLength,
+    billedCharacters: props.billingDetails?.neuralCharacters,
+  };
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500);
+  } catch {
+    return '';
+  }
+}

--- a/src/domain/audio/providers/azure-speech.ts
+++ b/src/domain/audio/providers/azure-speech.ts
@@ -27,7 +27,7 @@ interface BatchJob {
 }
 
 function baseUrl() {
-  return `https://${getAzureSpeechConfig().resource}.cognitiveservices.azure.com/texttospeech/batchsyntheses`;
+  return `${getAzureSpeechConfig().endpoint}/texttospeech/batchsyntheses`;
 }
 
 function authHeaders(): Record<string, string> {

--- a/src/domain/audio/providers/speech-provider.ts
+++ b/src/domain/audio/providers/speech-provider.ts
@@ -1,0 +1,51 @@
+import { AudioProvider } from '@prisma/client';
+
+/**
+ * The one interface the rest of the app talks to. Vendor specifics
+ * (endpoints, auth, polling, result packaging) stay behind it.
+ *
+ * A provider may be asynchronous (returns a job to poll) or synchronous
+ * (returns the audio on submit). Callers handle both through `SubmitOutcome`.
+ */
+
+export interface SynthesisRequest {
+  /** Caller-chosen id; providers that accept one use it so retries are idempotent. */
+  jobId: string;
+  ssml: string;
+}
+
+export interface SynthesisResult {
+  audio: Uint8Array;
+  contentType: string;
+  durationMs?: number;
+  sizeBytes?: number;
+  billedCharacters?: number;
+}
+
+export type SubmitOutcome = { kind: 'job'; jobId: string } | { kind: 'result'; result: SynthesisResult };
+
+export type PollOutcome =
+  | { kind: 'running' }
+  | { kind: 'succeeded'; result: SynthesisResult }
+  | { kind: 'failed'; message: string };
+
+export interface SpeechProvider {
+  readonly id: AudioProvider;
+  /** Longest single <break> the provider honours, in milliseconds. */
+  readonly maxBreakMs: number;
+  isConfigured(): boolean;
+  submit(request: SynthesisRequest): Promise<SubmitOutcome>;
+  poll(jobId: string): Promise<PollOutcome>;
+}
+
+export function getSpeechProvider(provider: AudioProvider): SpeechProvider {
+  switch (provider) {
+    case AudioProvider.AZURE_SPEECH: {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { azureSpeechProvider } = require('./azure-speech') as typeof import('./azure-speech');
+      return azureSpeechProvider;
+    }
+    default:
+      throw new Error(`Unknown speech provider: ${provider}`);
+  }
+}

--- a/src/domain/document-version/document-version.actions.ts
+++ b/src/domain/document-version/document-version.actions.ts
@@ -5,6 +5,7 @@ import { authorize } from '@/lib/authorize';
 import { type SessionUser } from '@/lib/session';
 import { DocumentStatus, ProjectRole, Role } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
+import type { AudioGenerationOutcome } from '../audio/audio.types';
 
 /**
  * Load a version + its language and assert the caller may edit/delete a source
@@ -201,6 +202,7 @@ export async function updateDocumentVersionStatusAction(
 ): Promise<{
   version: Awaited<ReturnType<typeof updateDocumentVersionStatus>>;
   github?: { status: 'success' | 'failed' | 'skipped'; error?: string; prUrl?: string };
+  audio?: AudioGenerationOutcome;
 }> {
   const { user } = await authorize('authenticated');
 
@@ -270,7 +272,21 @@ export async function updateDocumentVersionStatusAction(
     }
   }
 
-  return { version, github };
+  // If transitioning to APPROVED, start audio generation. Same shape as the
+  // GitHub deploy above: never throws, the outcome is reported to the caller.
+  let audio: AudioGenerationOutcome | undefined;
+  if (status === DocumentStatus.APPROVED) {
+    try {
+      const { startGeneration } = await import('../audio/audio.service');
+      audio = await startGeneration(version.id, user.id);
+      revalidatePath(`/documents/${version.documentId}/review`);
+    } catch (error: unknown) {
+      console.error('[Audio] Generation failed:', error);
+      audio = { status: 'failed', error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  return { version, github, audio };
 }
 
 export async function assignDocumentVersionAction(input: unknown) {

--- a/src/lib/audio-storage-config.ts
+++ b/src/lib/audio-storage-config.ts
@@ -6,6 +6,14 @@ const audioStorageConfigSchema = z.object({
   bucket: z.string({ error: 'AUDIO_S3_BUCKET is required' }).min(1, 'AUDIO_S3_BUCKET is required'),
   accessKeyId: z.string({ error: 'AUDIO_S3_ACCESS_KEY_ID is required' }).min(1, 'AUDIO_S3_ACCESS_KEY_ID is required'),
   secretAccessKey: z.string({ error: 'AUDIO_S3_SECRET_ACCESS_KEY is required' }).min(1, 'AUDIO_S3_SECRET_ACCESS_KEY is required'),
+  /**
+   * Folder that separates environments sharing one bucket, e.g. `production`,
+   * `staging`, `local`. Required, so an environment that forgets it skips audio
+   * instead of writing next to production files.
+   */
+  keyPrefix: z
+    .string({ error: 'AUDIO_S3_KEY_PREFIX is required (e.g. production, staging, local)' })
+    .regex(/^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/, 'AUDIO_S3_KEY_PREFIX must be a plain folder name like "staging"'),
   /** Base URL the bucket is publicly readable from; object keys are appended to it. */
   publicBaseUrl: z.string({ error: 'AUDIO_S3_PUBLIC_BASE_URL must be a URL' }).url('AUDIO_S3_PUBLIC_BASE_URL must be a URL'),
   /** Path-style addressing (`endpoint/bucket/key`) is what MinIO and most self-hosted S3 clones expect. */
@@ -25,6 +33,7 @@ export function getAudioStorageConfig(): AudioStorageConfig {
     bucket: process.env.AUDIO_S3_BUCKET,
     accessKeyId: process.env.AUDIO_S3_ACCESS_KEY_ID,
     secretAccessKey: process.env.AUDIO_S3_SECRET_ACCESS_KEY,
+    keyPrefix: process.env.AUDIO_S3_KEY_PREFIX?.replace(/^\/+|\/+$/g, ''),
     publicBaseUrl: process.env.AUDIO_S3_PUBLIC_BASE_URL,
     forcePathStyle: process.env.AUDIO_S3_FORCE_PATH_STYLE !== 'false',
   });

--- a/src/lib/audio-storage-config.ts
+++ b/src/lib/audio-storage-config.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+const audioStorageConfigSchema = z.object({
+  endpoint: z.string({ error: 'AUDIO_S3_ENDPOINT must be a URL' }).url('AUDIO_S3_ENDPOINT must be a URL'),
+  region: z.string({ error: 'AUDIO_S3_REGION is required' }).min(1, 'AUDIO_S3_REGION is required'),
+  bucket: z.string({ error: 'AUDIO_S3_BUCKET is required' }).min(1, 'AUDIO_S3_BUCKET is required'),
+  accessKeyId: z.string({ error: 'AUDIO_S3_ACCESS_KEY_ID is required' }).min(1, 'AUDIO_S3_ACCESS_KEY_ID is required'),
+  secretAccessKey: z.string({ error: 'AUDIO_S3_SECRET_ACCESS_KEY is required' }).min(1, 'AUDIO_S3_SECRET_ACCESS_KEY is required'),
+  /** Base URL the bucket is publicly readable from; object keys are appended to it. */
+  publicBaseUrl: z.string({ error: 'AUDIO_S3_PUBLIC_BASE_URL must be a URL' }).url('AUDIO_S3_PUBLIC_BASE_URL must be a URL'),
+  /** Path-style addressing (`endpoint/bucket/key`) is what MinIO and most self-hosted S3 clones expect. */
+  forcePathStyle: z.boolean(),
+});
+
+export type AudioStorageConfig = z.infer<typeof audioStorageConfigSchema>;
+
+let cachedConfig: AudioStorageConfig | null = null;
+
+export function getAudioStorageConfig(): AudioStorageConfig {
+  if (cachedConfig) return cachedConfig;
+
+  const result = audioStorageConfigSchema.safeParse({
+    endpoint: process.env.AUDIO_S3_ENDPOINT,
+    region: process.env.AUDIO_S3_REGION ?? 'auto',
+    bucket: process.env.AUDIO_S3_BUCKET,
+    accessKeyId: process.env.AUDIO_S3_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AUDIO_S3_SECRET_ACCESS_KEY,
+    publicBaseUrl: process.env.AUDIO_S3_PUBLIC_BASE_URL,
+    forcePathStyle: process.env.AUDIO_S3_FORCE_PATH_STYLE !== 'false',
+  });
+
+  if (!result.success) {
+    const errors = result.error.issues.map((i) => i.message).join(', ');
+    throw new Error(`Audio storage configuration is incomplete: ${errors}`);
+  }
+
+  cachedConfig = result.data;
+  return cachedConfig;
+}
+
+export function isAudioStorageConfigured(): boolean {
+  try {
+    getAudioStorageConfig();
+    return true;
+  } catch (error: unknown) {
+    console.log('[AudioStorage] Not configured:', error instanceof Error ? error.message : error);
+    return false;
+  }
+}

--- a/src/lib/azure-speech-config.ts
+++ b/src/lib/azure-speech-config.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const azureSpeechConfigSchema = z.object({
+  resource: z.string({ error: 'AZURE_SPEECH_RESOURCE is required' }).min(1, 'AZURE_SPEECH_RESOURCE is required'),
+  key: z.string({ error: 'AZURE_SPEECH_KEY is required' }).min(1, 'AZURE_SPEECH_KEY is required'),
+});
+
+export type AzureSpeechConfig = z.infer<typeof azureSpeechConfigSchema>;
+
+let cachedConfig: AzureSpeechConfig | null = null;
+
+export function getAzureSpeechConfig(): AzureSpeechConfig {
+  if (cachedConfig) return cachedConfig;
+
+  const result = azureSpeechConfigSchema.safeParse({
+    resource: process.env.AZURE_SPEECH_RESOURCE,
+    key: process.env.AZURE_SPEECH_KEY,
+  });
+
+  if (!result.success) {
+    const errors = result.error.issues.map((i) => i.message).join(', ');
+    throw new Error(`Azure Speech configuration is incomplete: ${errors}`);
+  }
+
+  cachedConfig = result.data;
+  return cachedConfig;
+}
+
+export function isAzureSpeechConfigured(): boolean {
+  try {
+    getAzureSpeechConfig();
+    return true;
+  } catch (error: unknown) {
+    console.log('[AzureSpeech] Not configured:', error instanceof Error ? error.message : error);
+    return false;
+  }
+}

--- a/src/lib/azure-speech-config.ts
+++ b/src/lib/azure-speech-config.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const azureSpeechConfigSchema = z.object({
-  /** Host from the resource's "Keys and Endpoint" page; either `{name}.cognitiveservices.azure.com` or `{region}.api.cognitive.microsoft.com` works. */
+  /** Host from the resource's "Keys and Endpoint" page; `{name}.cognitiveservices.azure.com` for a custom-domain resource, or `{region}.api.cognitive.microsoft.com` for a region key (scripts/azure-find-region.ts finds the region). Batch synthesis needs the Standard S0 tier; F0 answers 401. */
   endpoint: z.string({ error: 'AZURE_SPEECH_ENDPOINT must be a URL' }).url('AZURE_SPEECH_ENDPOINT must be a URL'),
   key: z.string({ error: 'AZURE_SPEECH_KEY is required' }).min(1, 'AZURE_SPEECH_KEY is required'),
 });

--- a/src/lib/azure-speech-config.ts
+++ b/src/lib/azure-speech-config.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
 const azureSpeechConfigSchema = z.object({
-  resource: z.string({ error: 'AZURE_SPEECH_RESOURCE is required' }).min(1, 'AZURE_SPEECH_RESOURCE is required'),
+  /** Host from the resource's "Keys and Endpoint" page; either `{name}.cognitiveservices.azure.com` or `{region}.api.cognitive.microsoft.com` works. */
+  endpoint: z.string({ error: 'AZURE_SPEECH_ENDPOINT must be a URL' }).url('AZURE_SPEECH_ENDPOINT must be a URL'),
   key: z.string({ error: 'AZURE_SPEECH_KEY is required' }).min(1, 'AZURE_SPEECH_KEY is required'),
 });
 
@@ -13,7 +14,7 @@ export function getAzureSpeechConfig(): AzureSpeechConfig {
   if (cachedConfig) return cachedConfig;
 
   const result = azureSpeechConfigSchema.safeParse({
-    resource: process.env.AZURE_SPEECH_RESOURCE,
+    endpoint: process.env.AZURE_SPEECH_ENDPOINT?.replace(/\/+$/, ''),
     key: process.env.AZURE_SPEECH_KEY,
   });
 

--- a/src/lib/object-storage.ts
+++ b/src/lib/object-storage.ts
@@ -1,0 +1,45 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getAudioStorageConfig } from './audio-storage-config';
+
+/**
+ * Thin wrapper over S3-compatible object storage. One operation, because
+ * that is all the app needs: write bytes under a key and get back the
+ * public URL they are readable from.
+ */
+
+let client: S3Client | null = null;
+
+function getClient(): S3Client {
+  if (client) return client;
+  const config = getAudioStorageConfig();
+  client = new S3Client({
+    endpoint: config.endpoint,
+    region: config.region,
+    forcePathStyle: config.forcePathStyle,
+    credentials: { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey },
+  });
+  return client;
+}
+
+export async function putObject(params: {
+  key: string;
+  body: Uint8Array;
+  contentType: string;
+}): Promise<{ url: string }> {
+  const config = getAudioStorageConfig();
+  await getClient().send(
+    new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: params.key,
+      Body: params.body,
+      ContentType: params.contentType,
+      CacheControl: 'public, max-age=31536000, immutable',
+    }),
+  );
+  return { url: publicUrlFor(params.key) };
+}
+
+export function publicUrlFor(key: string): string {
+  const base = getAudioStorageConfig().publicBaseUrl.replace(/\/+$/, '');
+  return `${base}/${key.split('/').map(encodeURIComponent).join('/')}`;
+}

--- a/src/lib/object-storage.ts
+++ b/src/lib/object-storage.ts
@@ -21,22 +21,28 @@ function getClient(): S3Client {
   return client;
 }
 
+/**
+ * Writes `body` under `{AUDIO_S3_KEY_PREFIX}/{key}` and returns the full key
+ * and its public URL. Callers pass environment-agnostic keys; the prefix is
+ * what keeps staging and production apart in a shared bucket.
+ */
 export async function putObject(params: {
   key: string;
   body: Uint8Array;
   contentType: string;
-}): Promise<{ url: string }> {
+}): Promise<{ key: string; url: string }> {
   const config = getAudioStorageConfig();
+  const key = `${config.keyPrefix}/${params.key.replace(/^\/+/, '')}`;
   await getClient().send(
     new PutObjectCommand({
       Bucket: config.bucket,
-      Key: params.key,
+      Key: key,
       Body: params.body,
       ContentType: params.contentType,
       CacheControl: 'public, max-age=31536000, immutable',
     }),
   );
-  return { url: publicUrlFor(params.key) };
+  return { key, url: publicUrlFor(key) };
 }
 
 export function publicUrlFor(key: string): string {


### PR DESCRIPTION
Implements #111, the tracer bullet of the audio PRD (#108). Stacked on #117; this branch also carries the `scripts/azure-tts-probe.ts` commit for #109, so merge #117 first and this PR shrinks to the audio slice.

## What changed

- **Schema** (`20260825101029_add_audio_files`): `AudioProvider`, `AudioStatus`, `AudioFile` (one row per generation, mirrors `GitHubCommit`), `Language.audioProvider` + `audioVoice`, `SourceProject.audioDocumentTypes` defaulting to `[DAY, DAILY_CONTENT]`.
- **Config gates**: `src/lib/azure-speech-config.ts`, `src/lib/audio-storage-config.ts`, same zod-and-cache shape as `github-config.ts`. Env vars: `AZURE_SPEECH_ENDPOINT` (URL from the Keys and Endpoint page), `AZURE_SPEECH_KEY`, `AUDIO_S3_ENDPOINT`, `AUDIO_S3_REGION` (default `auto`), `AUDIO_S3_BUCKET`, `AUDIO_S3_ACCESS_KEY_ID`, `AUDIO_S3_SECRET_ACCESS_KEY`, `AUDIO_S3_PUBLIC_BASE_URL`, `AUDIO_S3_FORCE_PATH_STYLE` (default `true`).
- **Storage**: `src/lib/object-storage.ts`, one `putObject` over `@aws-sdk/client-s3`.
- **Provider**: `src/domain/audio/providers/speech-provider.ts` interface (`submit` may return a job or a finished result) and `azure-speech.ts` (batch synthesis, job id `th-{audioFileId}` so a retried submit hits 409 and reuses, ZIP unpacked with `fflate`).
- **Service**: `startGeneration` runs on the transition into APPROVED inside `updateDocumentVersionStatusAction`, wrapped like the GitHub deploy; the action now returns `audio: { status: 'success' | 'skipped' | 'failed' }`. `advanceJob` polls, uploads and marks READY/FAILED, guarded by an `updateMany` claim from PENDING to PROCESSING.
- **UI**: `src/components/audio-status.tsx` in the review sidebar above the GitHub card. Polls `advanceAudioJobAction` every 5 s while in flight; READY shows `<audio controls>`, Download and Copy URL; FAILED shows the error. Renders nothing when no generation exists.
- Activity log actions `audio_generation_started`, `audio_generated`, `audio_generation_failed`.

Deferred to later slices as planned: regenerate/retry and stale badge (#112), admin fields (#113), sweep (#114).

## Verification

- `pnpm test`: 221 passing (new `audio.paths.test.ts`).
- `tsc --noEmit` clean; new files lint clean; repo-wide lint count unchanged from `develop` (187).
- Migration applied to the local DB.
- Skip path exercised against the local DB with a script: no voice → `no_voice_for_language`, voice but no storage env → `storage_not_configured`, storage but no Azure → `provider_not_configured`; zero `AudioFile` rows written in all three cases.
- **Not yet verified**: the happy path (Azure job → ZIP → S3 → player). Needs the Azure key and bucket from #109. I'll run it on staging once those exist and report here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)