### PR TITLE
fix(sidebar): long file paths no longer widen the sidebar

### DIFF
--- a/src/components/audio-status.tsx
+++ b/src/components/audio-status.tsx
@@ -177,7 +177,7 @@ export function AudioStatus({
           <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
           <div className="min-w-0">
             <p className="font-medium">{errorTitle(error.kind)}</p>
-            <p className="text-sm break-words">{error.message}</p>
+            <p className="text-sm break-all">{error.message}</p>
             {error.kind === 'configuration' && (
               <p className="text-xs text-gray-500 mt-1">Retrying will not help until the configuration is fixed.</p>
             )}

--- a/src/components/github-status.tsx
+++ b/src/components/github-status.tsx
@@ -137,7 +137,7 @@ export function GitHubStatus({ documentVersionId, isDeployed, compact = false, f
       {!loading && commits.length > 0 && (
         <div className="space-y-4">
           {commits.map((commit) => (
-            <div key={commit.id} className="border rounded p-3 space-y-1.5">
+            <div key={commit.id} className={frame === 'section' ? 'space-y-1.5 min-w-0' : 'border rounded p-3 space-y-1.5 min-w-0'}>
               {commit.errorMessage ? (
                 <div className="flex items-start gap-2 text-red-600">
                   <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
@@ -157,14 +157,14 @@ export function GitHubStatus({ documentVersionId, isDeployed, compact = false, f
                     <code className="bg-gray-100 px-2 py-0.5 rounded text-xs">{commit.commitSha.substring(0, 7)}</code>
                   </div>
 
-                  <div className="flex items-center gap-2 text-sm">
-                    <span className="text-gray-500">Branch:</span>
-                    <span>{commit.branchName}</span>
+                  <div className="flex items-start gap-2 text-sm min-w-0">
+                    <span className="text-gray-500 shrink-0">Branch:</span>
+                    <span className="break-all">{commit.branchName}</span>
                   </div>
 
-                  <div className="flex items-center gap-2 text-sm">
-                    <span className="text-gray-500">File:</span>
-                    <code className="bg-gray-100 px-2 py-0.5 rounded text-xs">{commit.filePath}</code>
+                  <div className="flex items-start gap-2 text-sm min-w-0">
+                    <span className="text-gray-500 shrink-0">File:</span>
+                    <code className="bg-gray-100 px-2 py-0.5 rounded text-xs break-all">{commit.filePath}</code>
                   </div>
 
                   {commit.prNumber && (

--- a/src/components/sidebar-section.tsx
+++ b/src/components/sidebar-section.tsx
@@ -25,7 +25,7 @@ export function SidebarSection({
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">{title}</span>
         {action}
       </div>
-      <div className={cn('px-3 py-3', contentClassName)}>{children}</div>
+      <div className={cn('px-3 py-3 min-w-0 overflow-hidden', contentClassName)}>{children}</div>
     </section>
   );
 }


### PR DESCRIPTION
Follow-up to #120, seen on staging: the deploy file path `translations/cs/exercises/lent2026/days/20.md` did not wrap and pushed the sidebar wider than the viewport.

- Code chips and branch names wrap with `break-all`.
- Section bodies are `min-w-0 overflow-hidden`, so no child can widen the sidebar.
- The GitHub panel drops its inner bordered box when rendered in the sidebar frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)