### PR TITLE
fix(audio): br keeps a line break, script and style blocks are never read

### DIFF
--- a/src/domain/audio/audio.script.test.ts
+++ b/src/domain/audio/audio.script.test.ts
@@ -92,3 +92,12 @@ test('empty input yields an empty script', () => {
 test('runs of blank lines collapse to a single paragraph break', () => {
   assert.equal(markdownToPlainText('A\n\n\n\n\nB'), 'A\n\nB');
 });
+
+test('inline HTML keeps its text, block tags and br separate lines, script and style are dropped whole', () => {
+  const md = 'Svíce <strong>Pokoje</strong>.<br>Druhý řádek <img src="x.png" alt="obrázek"> konec.<div>Uvnitř</div><script>alert(1)</script><style>p{}</style>Amen.';
+  assert.equal(markdownToPlainText(md), 'Svíce Pokoje.\nDruhý řádek  konec.\nUvnitř\nAmen.');
+});
+
+test('literal angle brackets and ampersands in prose survive stripping (the SSML builder escapes them)', () => {
+  assert.equal(markdownToPlainText('2 < 3 a Tom & Jerry'), '2 < 3 a Tom & Jerry');
+});

--- a/src/domain/audio/audio.script.ts
+++ b/src/domain/audio/audio.script.ts
@@ -61,7 +61,11 @@ function stripFrontmatter(markdown: string): string {
  * fences) and pulling in a full parser buys little here.
  */
 export function markdownToPlainText(markdown: string): string {
-  let text = markdown.replace(ANY_HTML_COMMENT, '');
+  let text = markdown
+    .replace(ANY_HTML_COMMENT, '')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '') // never read code or CSS aloud
+    .replace(/<br\s*\/?>/gi, '\n') // line breaks stay line breaks
+    .replace(/<\/?(p|div|h[1-6]|li|ul|ol|blockquote|section|article|tr|table)\b[^>]*>/gi, '\n'); // block tags separate text
 
   // Fenced code: drop the fence lines, keep whatever is inside.
   text = text.replace(/^[ \t]*(`{3,}|~{3,})[^\n]*\n?/gm, '');


### PR DESCRIPTION
Found while walking through how the audio pipeline treats HTML.

- `<br>` and block-level tags (`p`, `div`, `h1-6`, `li`, `blockquote`, …) now become line breaks instead of vanishing, so "Pokoje.<br>Druhý" no longer reads as one word.
- `<script>` and `<style>` blocks are dropped with their contents; previously the code inside would have been spoken.
- Inline tags still keep their text; literal `<`, `>`, `&` in prose still pass through and are XML-escaped by the SSML builder.

Two new tests; 237 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)